### PR TITLE
Refactor isDNDEnabled function to work for macOS 11+

### DIFF
--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -245,7 +245,6 @@ func isDNDEnabled() -> Bool {
         return suite?.bool(forKey: "NSStatusItem Visible DoNotDisturb") ?? false
         
     }
-    quitDialog(exitCode: 21, exitMessage: "DND Prefs unavailable", observedObject: DialogUpdatableContent())
     return false
 }
 

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -223,25 +223,29 @@ func plistFromData(_ data: Data) throws -> [String: Any] {
 
 func isDNDEnabled() -> Bool {
     // check for DND and return true if it is on
-    // ** This function will not work under macOS 12 as at July 2021
-    let consoleUser = SCDynamicStoreCopyConsoleUser(nil, nil , nil)
-    let consoleUserHomeDir = FileManager.default.homeDirectory(forUser: consoleUser! as String)?.path ?? ""
 
-    let ncprefsUrl = URL(
-        fileURLWithPath: String("\(consoleUserHomeDir)/Library/Preferences/com.apple.ncprefs.plist")
-    )
-
-    do {
-        let prefsList = try plistFromData(try Data(contentsOf: ncprefsUrl))
-        let dndPrefsData = prefsList["dnd_prefs"] as! Data
-        let dndPrefsList = try plistFromData(dndPrefsData)
-
-        if let userPref = dndPrefsList["userPref"] as? [String: Any] {
-            return userPref["enabled"] as! Bool
-        }
-    } catch {
-        quitDialog(exitCode: 21, exitMessage: "DND Prefs unavailable", observedObject: DialogUpdatableContent())
+    let processInfo = ProcessInfo.processInfo
+    let bigSur = OperatingSystemVersion(majorVersion: 11, minorVersion: 0, patchVersion: 0)
+    let monterey = OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 0)
+    
+    guard processInfo.isOperatingSystemAtLeast(bigSur) else {
+        return false
     }
+
+    if processInfo.isOperatingSystemAtLeast(monterey) {
+        
+        let suite = UserDefaults(suiteName: "com.apple.controlcenter")
+        
+        return suite?.bool(forKey: "NSStatusItem Visible FocusModes") ?? false
+        
+    } else if processInfo.isOperatingSystemAtLeast(bigSur) {
+        
+        let suite = UserDefaults(suiteName: "com.apple.controlcenter")
+        
+        return suite?.bool(forKey: "NSStatusItem Visible DoNotDisturb") ?? false
+        
+    }
+    quitDialog(exitCode: 21, exitMessage: "DND Prefs unavailable", observedObject: DialogUpdatableContent())
     return false
 }
 


### PR DESCRIPTION
This should make the isDNDEnabled work for macOS 11+. This does assume that Dialog.app is executed by the currently logged-in user (which is how Dialog.app is meant to be executed).

Thanks for all the hard work with this project @bartreardon!