### PR TITLE
swiftDialog v2.3.2

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -879,7 +879,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -908,7 +908,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog/Classes/DialogUpdatableContent.swift
+++ b/dialog/Classes/DialogUpdatableContent.swift
@@ -15,6 +15,14 @@ enum StatusState {
     case done
 }
 
+// swiftlint:disable force_try
+class StandardError: TextOutputStream {
+  func write(_ string: String) {
+    try! FileHandle.standardError.write(contentsOf: Data(string.utf8))
+  }
+}
+// swiftlint:enable force_try
+
 class FileReader {
     /// Provided by Joel Rennich
 
@@ -34,6 +42,14 @@ class FileReader {
     }
 
     func monitorFile() throws {
+            //print("mod date is less than now")
+        //}
+
+        /*
+
+         if getModificationDateOf(self.fileURL) > Date.now {
+         }
+         */
 
         try self.fileHandle = FileHandle(forReadingFrom: fileURL)
         if let data = try? self.fileHandle?.readToEnd() {
@@ -52,9 +68,10 @@ class FileReader {
                 do {
                     try self.monitorFile()
                 } catch {
-                    print("Error: \(error.localizedDescription)")
+                    writeLog("Error: \(error.localizedDescription)", logLevel: .error)
                 }
             }
+
         }
 
         dataReady = NotificationCenter.default.addObserver(forName: Process.didTerminateNotification,
@@ -77,7 +94,11 @@ class FileReader {
     }
 
     private func processCommands(commands: String) {
-
+        //print(getModificationDateOf(self.fileURL))
+        //print(Date.now)
+        if getModificationDateOf(self.fileURL) < observedData.appProperties.launchTime {
+            return
+        }
         let allCommands = commands.components(separatedBy: "\n")
 
         for line in allCommands {

--- a/dialog/Classes/DialogUpdatableContent.swift
+++ b/dialog/Classes/DialogUpdatableContent.swift
@@ -581,7 +581,7 @@ class DialogUpdatableContent: ObservableObject {
                 try manager.removeItem(atPath: path)
                 //NSLog("Deleted Dialog command file")
             } catch {
-                writeLog("Unable to delete command file", logLevel: .error)
+                writeLog("Unable to delete command file", logLevel: .debug)
             }
         }
     }

--- a/dialog/Classes/DialogUpdatableContent.swift
+++ b/dialog/Classes/DialogUpdatableContent.swift
@@ -183,6 +183,7 @@ class FileReader {
 
             //Progress Bar Label
             case "\(observedData.args.progressText.long):".lowercased():
+                observedData.args.progressText.present = true
                 observedData.args.progressText.value = line.replacingOccurrences(of: "\(observedData.args.progressText.long): ", with: "", options: .caseInsensitive)
 
             // Button 1 label

--- a/dialog/Classes/DialogUpdatableContent.swift
+++ b/dialog/Classes/DialogUpdatableContent.swift
@@ -581,8 +581,11 @@ class DialogUpdatableContent: ObservableObject {
             do {
                 try text.write(toFile: path, atomically: false, encoding: String.Encoding.utf8)
             } catch {
-                writeLog("Existing file at \(commandFilePath) but couldn't clean. ", logLevel: .error)
-                writeLog("Error info: \(error)", logLevel: .error)
+                if !manager.isReadableFile(atPath: commandFilePath) {
+                    writeLog(" Existing file at \(commandFilePath) is not readable\n\tCommands set to \(commandFilePath) will not be processed\n"
+                             , logLevel: .error)
+                    writeLog("\(error)\n", logLevel: .error)
+                }
             }
         } else {
             writeLog("Creating file at \(commandFilePath)")
@@ -602,7 +605,8 @@ class DialogUpdatableContent: ObservableObject {
                 try manager.removeItem(atPath: path)
                 //NSLog("Deleted Dialog command file")
             } catch {
-                writeLog("Unable to delete command file", logLevel: .debug)
+                writeLog("Unable to delete file at path \(path)", logLevel: .debug)
+                writeLog("\(error)", logLevel: .debug)
             }
         }
     }

--- a/dialog/Functions/Log.swift
+++ b/dialog/Functions/Log.swift
@@ -10,11 +10,12 @@ import OSLog
 
 func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog) {
     let logMessage = "\(message)"
+    var standardError = StandardError()
 
     os_log("%{public}@", log: log, type: logLevel, logMessage)
     if logLevel == .error || (logLevel == .debug && appvars.debugMode) {
-        // print debug and error to stdout
-        print("\(oslogTypeToString(logLevel).uppercased()): \(message)")
+        // print debug and error to sterr
+        print("\(oslogTypeToString(logLevel).uppercased()): \(message)", to: &standardError)
     }
 }
 

--- a/dialog/Functions/Log.swift
+++ b/dialog/Functions/Log.swift
@@ -13,7 +13,7 @@ func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog
     var standardError = StandardError()
 
     os_log("%{public}@", log: log, type: logLevel, logMessage)
-    if logLevel == .error || (logLevel == .debug && appvars.debugMode) {
+    if logLevel == .error || appvars.debugMode {
         // print debug and error to sterr
         print("\(oslogTypeToString(logLevel).uppercased()): \(message)", to: &standardError)
     }

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -24,8 +24,8 @@ func sendNotification(title: String = "", subtitle: String = "", message: String
     let notification = UNUserNotificationCenter.current()
     notification.requestAuthorization(options: [.alert, .sound]) { _, error in
         if let error = error {
-            print("Notifications are not available: \(error.localizedDescription as Any)")
-            print("Check to see if Notifications for Dialog.app are enabled in notification center")
+            writeLog("Notifications are not available: \(error.localizedDescription as Any)", logLevel: .error)
+            writeLog("Check to see if Notifications for Dialog.app are enabled in notification center", logLevel: .error)
         }
     }
 
@@ -62,7 +62,7 @@ func sendNotification(title: String = "", subtitle: String = "", message: String
                         let attachment = try UNNotificationAttachment(identifier: "AttachedContent", url: fileURL)
                         content.attachments = [attachment]
                     } catch let error {
-                        print(error.localizedDescription)
+                        writeLog(error.localizedDescription, logLevel: .error)
                     }
 
                 }
@@ -75,17 +75,17 @@ func sendNotification(title: String = "", subtitle: String = "", message: String
                 // Schedule the request with the system.
                 notification.add(request) { (error) in
                    if error != nil {
-                       print(error?.localizedDescription as Any)
+                       writeLog(error?.localizedDescription ?? "Notification error", logLevel: .error)
                    }
                 }
             case .provisional:
-                print("Notification authorisation is provisional")
+                writeLog("Notification authorisation is provisional")
             case .denied:
-                print("Notification authorisation is denied")
+                writeLog("Notification authorisation is denied")
             case .notDetermined:
-                print("Notification authorisation cannot be determined")
+                writeLog("Notification authorisation cannot be determined")
             default:
-                print("Notifications aren't authorised")
+            writeLog("Notifications aren't authorised")
         }
     }
 }

--- a/dialog/Functions/ProcessCLOptions.swift
+++ b/dialog/Functions/ProcessCLOptions.swift
@@ -564,7 +564,7 @@ func processCLOptions(json: JSON = getJSON()) {
             }
             if json[appArguments.titleFont.long]["colour"].exists() {
                 appvars.titleFontColour = stringToColour(json[appArguments.titleFont.long]["colour"].stringValue)
-                print("found a colour of \(json[appArguments.titleFont.long]["colour"].stringValue)")
+                writeLog("found a colour of \(json[appArguments.titleFont.long]["colour"].stringValue)", logLevel: .debug)
             } else if json[appArguments.titleFont.long]["color"].exists() {
                 appvars.titleFontColour = stringToColour(json[appArguments.titleFont.long]["color"].stringValue)
             }
@@ -572,8 +572,7 @@ func processCLOptions(json: JSON = getJSON()) {
                 appvars.titleFontName = json[appArguments.titleFont.long]["name"].stringValue
             }
         } else {
-
-                                    writeLog("titleFont.value : \(appArguments.titleFont.value)")
+            writeLog("titleFont.value : \(appArguments.titleFont.value)")
             let fontCLValues = appArguments.titleFont.value
             var fontValues = [""]
             //split by ,

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -266,3 +266,14 @@ func getVideoStreamingURLFromID(videoid: String, autoplay: Bool = false) -> Stri
     writeLog("video url is \(fullURL)")
     return fullURL
 }
+
+func getModificationDateOf(_ fileURL: URL) -> Date {
+    var theDate: Date = Date.now
+    do {
+        let attr = try FileManager.default.attributesOfItem(atPath: fileURL.absoluteString)
+        theDate = attr[FileAttributeKey.modificationDate] as! Date
+    } catch {
+        writeLog("Failed to get file creation date: \(error.localizedDescription)", logLevel: .error)
+    }
+    return theDate
+}

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -227,23 +227,23 @@ func isDNDEnabled() -> Bool {
     let processInfo = ProcessInfo.processInfo
     let bigSur = OperatingSystemVersion(majorVersion: 11, minorVersion: 0, patchVersion: 0)
     let monterey = OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 0)
-    
+
     guard processInfo.isOperatingSystemAtLeast(bigSur) else {
         return false
     }
 
     if processInfo.isOperatingSystemAtLeast(monterey) {
-        
+
         let suite = UserDefaults(suiteName: "com.apple.controlcenter")
-        
+
         return suite?.bool(forKey: "NSStatusItem Visible FocusModes") ?? false
-        
+
     } else if processInfo.isOperatingSystemAtLeast(bigSur) {
-        
+
         let suite = UserDefaults(suiteName: "com.apple.controlcenter")
-        
+
         return suite?.bool(forKey: "NSStatusItem Visible DoNotDisturb") ?? false
-        
+
     }
     return false
 }

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4724</string>
+	<string>4725</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4725</string>
+	<string>4726</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4717</string>
+	<string>4721</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4721</string>
+	<string>4722</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4722</string>
+	<string>4724</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -5,6 +5,8 @@ dialogpath="/Library/Application Support/Dialog/Dialog.app"
 dialogbin="$dialogpath/Contents/MacOS/Dialog"
 commandfile=$(echo "$@" | awk -v pattern="--commandfile" '{for (i=0;i<=NF;i++) {if ($i==pattern) print $(i+1) }}')
 
+echoerr() { echo "$@" 1>&2; }
+
 if [[ -z $commandfile ]]; then
     commandfile="/var/tmp/dialog.log"
 fi
@@ -17,22 +19,19 @@ runAsUser() {
   if [ "$currentUser" != "loginwindow" ]; then
     launchctl asuser "$uid" sudo -u "$currentUser" "$@"
   else
-    echo "no user logged in"
-    # uncomment the exit command
-    # to make the function exit with an error when no user is logged in
-    # exit 1
+    echoerr "no user logged in"
   fi
 }
 
 # Check to make sure we have a binary to run
 if [ ! -e "$dialogbin" ]; then
-    echo "Cannot find swiftDialog binary at $dialogbin"
+    echoerr "Cannot find swiftDialog binary at $dialogbin"
     exit 255
 fi
 
 # check we have a valid console user
 if [ "$currentUser" = "loginwindow" ] || [ -z $currentUser ]; then
-    echo "Cannot run. No console user, or at loginwindow."
+    echoerr "Cannot run. No console user, or at loginwindow."
     exit 255
 fi
 
@@ -41,9 +40,11 @@ if [[ ! -e "$commandfile" ]]; then
     /usr/bin/touch "$commandfile"
 # check to see if the command file is writeable
 elif [[ ! -w "$commandfile" ]]; then
-    echo "Warning: command file ${commandfile} is non zero and not writeable by user $currentUser"
-    echo "${commandfile} cannot be cleaned prior to launch. Behaviour may be unpredictable"
-    echo "re-run this command as root to rectify this issue"
+    echoerr ""
+    echoerr "WARNING: command file ${commandfile} is non zero and not writeable by user $currentUser"
+    echoerr "  ${commandfile} cannot be cleaned prior to launch. Behaviour may be unpredictable"
+    echoerr "  re-run this command as root to rectify this issue"
+    echoerr ""
 fi
 
 # If we're running as root, launch swiftDialog as the user.

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -5,6 +5,10 @@ dialogpath="/Library/Application Support/Dialog/Dialog.app"
 dialogbin="$dialogpath/Contents/MacOS/Dialog"
 commandfile=$(echo "$@" | awk -v pattern="--commandfile" '{for (i=0;i<=NF;i++) {if ($i==pattern) print $(i+1) }}')
 
+if [[ -z $commandfile ]]; then
+    commandfile="/var/tmp/dialog.log"
+fi
+
 # convenience function to run a command as the current user
 # usage:
 #   runAsUser command arguments...
@@ -32,11 +36,20 @@ if [ "$currentUser" = "loginwindow" ] || [ -z $currentUser ]; then
     exit 255
 fi
 
+# check to see if the command file exists
+if [[ ! -e "$commandfile" ]]; then
+    /usr/bin/touch "$commandfile"
+# check to see if the command file is writeable
+elif [[ ! -w "$commandfile" ]]; then
+    echo "Warning: command file ${commandfile} is non zero and not writeable by user $currentUser"
+    echo "${commandfile} cannot be cleaned prior to launch. Behaviour may be unpredictable"
+    echo "re-run this command as root to rectify this issue"
+fi
+
 # If we're running as root, launch swiftDialog as the user.
 if [ $(id -u) -eq 0 ]; then
-    if [ ! -z $commandfile ]; then
-        # a command file is being used - make sure the console user has read access to it.
-        /usr/bin/touch "$commandfile"
+    if [ -e $commandfile ]; then
+        # make sure the console user has read access to the command file
         /bin/chmod 666 "$commandfile"
     fi
 

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -33,7 +33,7 @@ fi
 if [[ ! -e "$commandfile" ]]; then
     /usr/bin/touch "$commandfile"
 # check to see if the command file is writeable
-elif [[ ! -w "$commandfile" ]]; then
+elif [[ ! -r "$commandfile" ]]; then
     echoerr ""
     echoerr "Warning: command file ${commandfile} is not empty and not writeable by user $currentUser"
     echoerr ""

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -35,7 +35,7 @@ if [[ ! -e "$commandfile" ]]; then
 # check to see if the command file is writeable
 elif [[ ! -r "$commandfile" ]]; then
     echoerr ""
-    echoerr "Warning: command file ${commandfile} is not empty and not writeable by user $currentUser"
+    echoerr "Warning: command file ${commandfile} is not readable by user $currentUser"
     echoerr ""
 fi
 

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -25,13 +25,7 @@ runAsUser() {
 
 # Check to make sure we have a binary to run
 if [ ! -e "$dialogbin" ]; then
-    echoerr "Cannot find swiftDialog binary at $dialogbin"
-    exit 255
-fi
-
-# check we have a valid console user
-if [ "$currentUser" = "loginwindow" ] || [ -z $currentUser ]; then
-    echoerr "Cannot run. No console user, or at loginwindow."
+    echoerr "ERROR: Cannot find swiftDialog binary at $dialogbin"
     exit 255
 fi
 
@@ -41,9 +35,7 @@ if [[ ! -e "$commandfile" ]]; then
 # check to see if the command file is writeable
 elif [[ ! -w "$commandfile" ]]; then
     echoerr ""
-    echoerr "WARNING: command file ${commandfile} is non zero and not writeable by user $currentUser"
-    echoerr "  ${commandfile} cannot be cleaned prior to launch. Behaviour may be unpredictable"
-    echoerr "  re-run this command as root to rectify this issue"
+    echoerr "Warning: command file ${commandfile} is not empty and not writeable by user $currentUser"
     echoerr ""
 fi
 

--- a/dialog/Structs/AppVariables.swift
+++ b/dialog/Structs/AppVariables.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct AppVariables {
 
-    var cliversion                      = "2.3.1"
+    var cliversion                      = "2.3.2"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)

--- a/dialog/Structs/AppVariables.swift
+++ b/dialog/Structs/AppVariables.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct AppVariables {
 
     var cliversion                      = "2.3.1"
-
+    let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)
     let messageDefault                  = String("default-message".localized)

--- a/dialog/Structs/ImageProcessing.swift
+++ b/dialog/Structs/ImageProcessing.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Combine
 import SwiftUI
+//import WebViewKit
+//import WebKit
 
 enum ImageSource {
     case remote(url: URL?)
@@ -77,10 +79,17 @@ struct DisplayImage: View {
         ZStack {
             if imgFromURL {
                 if ["svg", "pdf"].contains(imgPath.split(separator: ".").last) {
-                    let legacyImage = getImageFromPath(fileImagePath: imgPath, returnErrorImage: false)
+                    let legacyImage = getImageFromPath(fileImagePath: imgPath, returnErrorImage: true)
                     Image(nsImage: legacyImage)
                         .resizable()
                         .interpolation(.high)
+                /* Reserved for future use
+                } else if ["gif"].contains(imgPath.split(separator: ".").last) {
+                    WebView(url: asyncURL) { webView in
+                        webView.configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+                    }
+                    .frame(width: .infinity, height: .infinity)
+                */
                 } else {
                     AsyncImage(url: asyncURL) { phase in
                         if let image = phase.image {

--- a/dialog/Views/ButtonView.swift
+++ b/dialog/Views/ButtonView.swift
@@ -67,6 +67,7 @@ struct ButtonView: View {
                     }
                     )
                     .keyboardShortcut(observedData.appProperties.button1DefaultAction)
+                    .disabled(observedData.args.button1Disabled.present)
                 }
                 Spacer()
                     .frame(width: 20)

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -115,11 +115,11 @@ struct dialogApp: App {
 
         //check debug mode and print info
         if appArguments.debug.present {
-            writeLog("debug options presented. dialog state sent to stdout")
+            writeLog("debug options presented. dialog state sent to stderr", logLevel: .debug)
             appvars.debugMode = true
             appvars.debugBorderColour = Color.green
 
-            writeLog("Window Height = \(appvars.windowHeight): Window Width = \(appvars.windowWidth)")
+            writeLog("Window Height = \(appvars.windowHeight): Window Width = \(appvars.windowWidth)", logLevel: .debug)
             /*
             print("\nApplication State Variables")
             let mirrored_appvars = Mirror(reflecting: appvars)
@@ -137,7 +137,7 @@ struct dialogApp: App {
             }
             */
         }
-        writeLog("width: \(appvars.windowWidth), height: \(appvars.windowHeight)")
+        writeLog("width: \(appvars.windowWidth), height: \(appvars.windowHeight)", logLevel: .debug)
 
         observedData = DialogUpdatableContent()
 
@@ -151,7 +151,7 @@ struct dialogApp: App {
         }
 
         // bring to front on launch
-        writeLog("Activating")
+        writeLog("Activating", logLevel: .debug)
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -170,14 +170,14 @@ struct dialogApp: App {
                     // Set window level
                     if appArguments.forceOnTop.present || appArguments.blurScreen.present {
                         window?.level = .floating
-                        writeLog("Window is forceed on top")
+                        writeLog("Window is forced on top", logLevel: .debug)
                     } else {
                         window?.level = .normal
                     }
 
                     // display a blur screen window on all screens.
                     if appArguments.blurScreen.present && !appArguments.fullScreenWindow.present {
-                        writeLog("Blurscreen enabled")
+                        writeLog("Blurscreen enabled", logLevel: .debug)
                         let screens = NSScreen.screens
                         for (index, screen) in screens.enumerated() {
                             observedData.blurredScreen.append(BlurWindowController())
@@ -194,7 +194,7 @@ struct dialogApp: App {
                     }
 
                     if appArguments.forceOnTop.present || appArguments.blurScreen.present {
-                        writeLog("Activating window")
+                        writeLog("Activating window", logLevel: .debug)
                         NSApp.activate(ignoringOtherApps: true)
                     }
                 }


### PR DESCRIPTION
 - `isDNDEnabled()` refactored to work under macOS 12+ (thanks @ryangball). Future use pending
 - updates to `/usr/local/bin/dialog` to handle errors a bit more cleanly and send errors to stderr instead of stdout
 - updates to general error and log handling sending error and debug output to stderr
 - Add a check of launch time and compare against command file modification date. if the command file is older then existing commands stored within will not be processed
 - command file processing is now less dependent on ownership or permissions. As long as the file is readable. Errors in this department provide more detail and output to stderr and should only occur if the file is not readable.
 - button1 respects `button1disabled` if centred
 - progress text will populate if updated by command file if dialog was launched with no progress text visible initially 