### PR TITLE
Enable User's Preferred Accent Colour & Fix `auto` Symbol Rendering 

### DIFF
--- a/dialog/Functions/Strings.swift
+++ b/dialog/Functions/Strings.swift
@@ -66,6 +66,8 @@ func stringToColour(_ colourValue: String) -> Color {
     } else {
         switch colourValue {
 
+        case "accent":
+            returnColor = Color.accentColor
         case "black":
             returnColor = Color.black
         case "blue":

--- a/dialog/Structs/HelpText.swift
+++ b/dialog/Structs/HelpText.swift
@@ -67,10 +67,12 @@ struct SDHelp {
         argument.titleFont.helpLong = """
         Can accept up to three parameters, in a comma seperated list, to modify font properties.
 
-            color,colour=<text><hex>  - specified in hex format, e.g. #00A4C7
-                                        Also accepts any of the standard Apple colours
-                                        black, blue, gray, green, orange, pink, purple, red, white, yellow
-                                        default if option is invalid is system primary colour
+            color,colour=<text><hex>  - accepts any of the following color specifiers:
+                                        * A standard macOS system color:
+                                            [black | blue | gray | green | orange | pink | purple | red | white | yellow]
+                                        * The user's preferred "Accent Color", specified with the string 'accent'
+                                        * A custom color specified in hex format, e.g. #00A4C7
+                                        Default: macOS system 'primary' color.
 
             size=<float>              - accepts any float value.
 
@@ -124,10 +126,12 @@ struct SDHelp {
         argument.messageFont.helpLong = """
         Can accept up to three parameters, in a comma seperated list, to modify font properties.
 
-            color,colour=<text><hex>  - specified in hex format, e.g. #00A4C7
-                                        Also accepts any of the standard Apple colours
-                                        black, blue, gray, green, orange, pink, purple, red, white, yellow
-                                        default if option is invalid is system primary colour
+            color,colour=<text><hex>  - accepts any of the following color specifiers:
+                                        * A standard macOS system color:
+                                            [black | blue | gray | green | orange | pink | purple | red | white | yellow]
+                                        * The user's preferred "Accent Color", specified with the string 'accent'
+                                        * A custom color specified in hex format, e.g. #00A4C7
+                                        Default: macOS system 'primary' color.
 
             size=<float>              - accepts any float value.
 
@@ -265,8 +269,12 @@ struct SDHelp {
 
         SF Symbols - visit https://developer.apple.com/sf-symbols/ for details on over 3,100 symbols
 
-        color,colour=<text><hex>          - specified in hex format, e.g. #00A4C7
-        bgcolor,bgcolour=<text><hex>
+        color,colour=<text><hex>          - accepts any of the following color specifiers:
+        bgcolor,bgcolour=<text><hex>        * A standard macOS system color:
+                                                [black | blue | gray | green | orange | pink | purple | red | white | yellow]
+                                            * The user's preferred "Accent Color", specified with the string 'accent'
+                                            * A custom color specified in hex format, e.g. #00A4C7
+                                            Default: macOS system 'primary' color.
         palette=<text><hex>               - palette accepts up to three colours for use in multicolour
                                             SF Symbols
                                             Use comma seperated values, e.g. palette=red,green,blue

--- a/dialog/Views/IconView.swift
+++ b/dialog/Views/IconView.swift
@@ -20,6 +20,7 @@ struct IconView: View {
     var imgFromBase64: Bool = false
 
     var builtInIconName: String = ""
+    var builtInIconAutoColor: Bool = false
     var builtInIconColour: Color = Color.primary
     var builtInIconSecondaryColour: Color = Color.secondary
     var builtInIconTertiaryColour: Color = Color.primary
@@ -143,7 +144,7 @@ struct IconView: View {
                             // this is a bit of a workaround in that we let the user determine if they want the multicolour SF symbol
                             // or a standard template style. sefault is template. "auto" will use the built in SF Symbol colours
                             iconRenderingMode = Image.TemplateRenderingMode.original
-                            //builtInIconColour =
+                            builtInIconAutoColor = true
                         } else {
                             //check to see if it's in the right length and only contains the right characters
                             iconRenderingMode = Image.TemplateRenderingMode.template // switches to monochrome which allows us to tint the sf symbol
@@ -242,7 +243,7 @@ struct IconView: View {
                                 .resizable()
                                 .renderingMode(iconRenderingMode)
                                 .font(Font.title.weight(builtInIconWeight))
-                                .symbolRenderingMode(.hierarchical)
+                                .symbolRenderingMode(builtInIconAutoColor ? .multicolor : .hierarchical)
                                 .foregroundStyle(builtInIconColour)
                         }
                     }


### PR DESCRIPTION
This change set will allow the user to specify a value of `accent` where macOS standard colour values are accepted, indicating that the colour applied should be the one chosen by the user via `System Settings > Appearance > Accent Colour`.  This affects the following:

- Title colour
- Message colour
- Icon colour (when a Symbol is specified for the icon)

This change set also addresses a discrepancy between the documentation, and the actual handling of multicolour SF Symbols when the colour value `auto` is specified.  Currently, this value does not actually allow the Symbol to be displayed in multicolour mode, as its `.symbolRenderingMode` is set to `.hierarchical`.  This is fixed by adding a `var` to track the usage of `auto`, and a check against that `var` to determine whether `.hierarchical` or `.multicolor` symbol rendering should be used.