### PR TITLE
Add Missing System Font Weights and Colors; Move Color/String/Font Utilities to Extensions

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		41D81E6C25F8209F00D1F7E1 /* CLOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E6B25F8209F00D1F7E1 /* CLOptions.swift */; };
 		41D81E7125F845D200D1F7E1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7025F845D200D1F7E1 /* AppState.swift */; };
 		41D81E7925F870A500D1F7E1 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7825F870A500D1F7E1 /* System.swift */; };
+		94072E492AFE931300B2A5C3 /* Font+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94072E482AFE931300B2A5C3 /* Font+Additions.swift */; };
 		CC21904B2A7B994A00269525 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904A2A7B994A00269525 /* Preferences.swift */; };
 		CC21904E2A7BC3E000269525 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904D2A7BC3E000269525 /* Strings.swift */; };
 		CC2190502A7BC9FE00269525 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904F2A7BC9FE00269525 /* Log.swift */; };
@@ -162,6 +163,7 @@
 		41D81E7825F870A500D1F7E1 /* System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = System.swift; sourceTree = "<group>"; };
 		41FD45FD26C40366006976FC /* TimerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		41FD45FF26C8DC5D006976FC /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		94072E482AFE931300B2A5C3 /* Font+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Additions.swift"; sourceTree = "<group>"; };
 		CC21904A2A7B994A00269525 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		CC21904D2A7BC3E000269525 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		CC21904F2A7BC9FE00269525 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				CC2190582A7BCDDD00269525 /* View+Additions.swift */,
 				CC8D962F2A01CCAB00CC84C6 /* Theme+sdMarkdown.swift */,
 				415934D926DB7604009C9C3A /* NSWindow+Additions.swift */,
+				94072E482AFE931300B2A5C3 /* Font+Additions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -685,6 +688,7 @@
 				CC21905D2A7BD7D300269525 /* AppVariables.swift in Sources */,
 				4124EFD229455861003B00F4 /* HelpView.swift in Sources */,
 				CC2190502A7BC9FE00269525 /* Log.swift in Sources */,
+				94072E492AFE931300B2A5C3 /* Font+Additions.swift in Sources */,
 				41D81E7925F870A500D1F7E1 /* System.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/dialog/Classes/DialogUpdatableContent.swift
+++ b/dialog/Classes/DialogUpdatableContent.swift
@@ -152,9 +152,9 @@ class FileReader {
                     case  "size":
                         observedData.appProperties.titleFontSize = string2float(string: item[1], defaultValue: appvars.titleFontSize)
                     case  "weight":
-                        observedData.appProperties.titleFontWeight = textToFontWeight(item[1])
+                        observedData.appProperties.titleFontWeight = Font.Weight(argument: item[1])
                     case  "colour","color":
-                        observedData.appProperties.titleFontColour = stringToColour(item[1])
+                        observedData.appProperties.titleFontColour = Color(argument: item[1])
                     case  "name":
                         observedData.appProperties.titleFontName = item[1]
                     case  "shadow":

--- a/dialog/Extensions/Colour+Additions.swift
+++ b/dialog/Extensions/Colour+Additions.swift
@@ -9,6 +9,17 @@ import Foundation
 import SwiftUI
 
 extension Color {
+
+    var hexValue: String {
+        let components = self.cgColor?.components
+        let red: CGFloat = components?[0] ?? 0.0
+        let green: CGFloat = components?[1] ?? 0.0
+        let blue: CGFloat = components?[2] ?? 0.0
+
+        let hexString = String.init(format: "#%02lX%02lX%02lX", lroundf(Float(red * 255)), lroundf(Float(green * 255)), lroundf(Float(blue * 255)))
+        return hexString
+    }
+
     init(hex: UInt, alpha: Double = 1) {
         self.init(
             .sRGB,
@@ -17,6 +28,51 @@ extension Color {
             blue: Double((hex >> 00) & 0xff) / 255,
             opacity: alpha
         )
+    }
+
+    /// convert to a colour from an argument string representation
+    init(argument: String)
+    {
+        let hexRegEx = "^#([a-fA-F0-9]{6})$"
+        let hexPred = NSPredicate(format: "SELF MATCHES %@", hexRegEx)
+
+        if hexPred.evaluate(with: argument) {
+
+            let colourRedValue = "\(argument[1])\(argument[2])"
+            let colourRed = Double(Int(colourRedValue, radix: 16)!)/255
+
+            let colourGreenValue = "\(argument[3])\(argument[4])"
+            let colourGreen = Double(Int(colourGreenValue, radix: 16)!)/255
+
+            let colourBlueValue = "\(argument[5])\(argument[6])"
+            let colourBlue = Double(Int(colourBlueValue, radix: 16)!)/255
+
+            self.init(red: colourRed, green: colourGreen, blue: colourBlue)
+
+            return
+        }
+
+        switch argument {
+            case "accent"    : self = .accentColor
+            case "red"       : self = .red
+            case "orange"    : self = .orange
+            case "yellow"    : self = .yellow
+            case "green"     : self = .green
+            case "mint"      : self = .mint
+            case "teal"      : self = .teal
+            case "cyan"      : self = .cyan
+            case "blue"      : self = .blue
+            case "indigo"    : self = .indigo
+            case "purple"    : self = .purple
+            case "pink"      : self = .pink
+            case "brown"     : self = .brown
+            case "white"     : self = .white
+            case "gray"      : self = .gray
+            case "black"     : self = .black
+            case "primary"   : self = .primary
+            case "secondary" : self = .secondary
+            default          : self = .primary
+        }
     }
 }
 

--- a/dialog/Extensions/Font+Additions.swift
+++ b/dialog/Extensions/Font+Additions.swift
@@ -1,0 +1,30 @@
+//
+//  Font+Additions.swift
+//  Dialog
+//
+//  Created by Matthew L. Judy on 2023/11/10.
+//
+
+import SwiftUI
+
+
+extension Font.Weight
+{
+    init(argument: String)
+    {
+        switch argument {
+            case "ultraLight" : self = .ultraLight
+            case "thin"       : self = .thin
+            case "light"      : self = .light
+            case "regular"    : self = .regular
+            case "medium"     : self = .medium
+            case "semibold"   : self = .semibold
+            case "bold"       : self = .bold
+            case "heavy"      : self = .heavy
+            case "black"      : self = .black
+            default           : self = .regular
+        }
+    }
+}
+
+

--- a/dialog/Extensions/String+Additions.swift
+++ b/dialog/Extensions/String+Additions.swift
@@ -6,8 +6,17 @@
 //
 
 import Foundation
+import CryptoKit
 
 extension String {
+
+    var sha256Hash: String {
+        // Returns a sha256 hash of the given text
+        let inputData = Data(self.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
     var localized: String {
       return NSLocalizedString(self, comment: "\(self)_comment")
     }

--- a/dialog/Functions/ProcessCLOptions.swift
+++ b/dialog/Functions/ProcessCLOptions.swift
@@ -94,7 +94,7 @@ func processCLOptions(json: JSON = getJSON()) {
             writeLog("Using environment key value", logLevel: .debug)
             authKey = environmentAuthKey
         }
-        if !checkAuthorisationKey(key: hashForString(authKey)) {
+        if !checkAuthorisationKey(key: authKey.sha256Hash) {
             writeLog("Auth key is required", logLevel: .debug)
             quitDialog(exitCode: appvars.exit30.code, exitMessage: appvars.exit30.message)
         } else {
@@ -104,7 +104,7 @@ func processCLOptions(json: JSON = getJSON()) {
 
     // hash a key value
     if appArguments.hash.present {
-        quitDialog(exitCode: 0, exitMessage: hashForString(appArguments.hash.value))
+        quitDialog(exitCode: 0, exitMessage: appArguments.hash.value.sha256Hash)
     }
 
     // Do some basic tag to markdown stuff
@@ -560,13 +560,13 @@ func processCLOptions(json: JSON = getJSON()) {
                 appvars.titleFontSize = string2float(string: json[appArguments.titleFont.long]["size"].stringValue, defaultValue: appvars.titleFontSize)
             }
             if json[appArguments.titleFont.long]["weight"].exists() {
-                appvars.titleFontWeight = textToFontWeight(json[appArguments.titleFont.long]["weight"].stringValue)
+                appvars.titleFontWeight = Font.Weight(argument: json[appArguments.titleFont.long]["weight"].stringValue)
             }
             if json[appArguments.titleFont.long]["colour"].exists() {
-                appvars.titleFontColour = stringToColour(json[appArguments.titleFont.long]["colour"].stringValue)
+                appvars.titleFontColour = Color(argument: json[appArguments.titleFont.long]["colour"].stringValue)
                 writeLog("found a colour of \(json[appArguments.titleFont.long]["colour"].stringValue)", logLevel: .debug)
             } else if json[appArguments.titleFont.long]["color"].exists() {
-                appvars.titleFontColour = stringToColour(json[appArguments.titleFont.long]["color"].stringValue)
+                appvars.titleFontColour = Color(argument: json[appArguments.titleFont.long]["color"].stringValue)
             }
             if json[appArguments.titleFont.long]["name"].exists() {
                 appvars.titleFontName = json[appArguments.titleFont.long]["name"].stringValue
@@ -586,10 +586,10 @@ func processCLOptions(json: JSON = getJSON()) {
                         appvars.titleFontSize = string2float(string: item[1], defaultValue: appvars.titleFontSize)
                                                 writeLog("titleFontSize : \(appvars.titleFontSize)")
                     case  "weight":
-                        appvars.titleFontWeight = textToFontWeight(item[1])
+                        appvars.titleFontWeight = Font.Weight(argument: item[1])
                                                 writeLog("titleFontWeight : \(appvars.titleFontWeight)")
                     case  "colour","color":
-                        appvars.titleFontColour = stringToColour(item[1])
+                        appvars.titleFontColour = Color(argument: item[1])
                                                 writeLog("titleFontColour : \(appvars.titleFontColour)")
                     case  "name":
                         appvars.titleFontName = item[1]
@@ -615,12 +615,12 @@ func processCLOptions(json: JSON = getJSON()) {
                 appvars.messageFontSize = string2float(string: json[appArguments.messageFont.long]["size"].stringValue, defaultValue: appvars.messageFontSize)
             }
             if json[appArguments.messageFont.long]["weight"].exists() {
-                appvars.messageFontWeight = textToFontWeight(json[appArguments.messageFont.long]["weight"].stringValue)
+                appvars.messageFontWeight = Font.Weight(argument: json[appArguments.messageFont.long]["weight"].stringValue)
             }
             if json[appArguments.messageFont.long]["colour"].exists() {
-                appvars.messageFontColour = stringToColour(json[appArguments.messageFont.long]["colour"].stringValue)
+                appvars.messageFontColour = Color(argument: json[appArguments.messageFont.long]["colour"].stringValue)
             } else if json[appArguments.messageFont.long]["color"].exists() {
-                appvars.messageFontColour = stringToColour(json[appArguments.messageFont.long]["color"].stringValue)
+                appvars.messageFontColour = Color(argument: json[appArguments.messageFont.long]["color"].stringValue)
             }
             if json[appArguments.messageFont.long]["name"].exists() {
                 appvars.messageFontName = json[appArguments.messageFont.long]["name"].stringValue
@@ -639,18 +639,18 @@ func processCLOptions(json: JSON = getJSON()) {
                 switch item[0] {
                     case "size":
                         appvars.messageFontSize = string2float(string: item[1], defaultValue: appvars.messageFontSize)
-                                                writeLog("messageFontSize : \(appvars.messageFontSize)")
+                        writeLog("messageFontSize : \(appvars.messageFontSize)")
                     case "weight":
-                        appvars.messageFontWeight = textToFontWeight(item[1])
-                                                writeLog("messageFontWeight : \(appvars.messageFontWeight)")
+                        appvars.messageFontWeight = Font.Weight(argument: item[1])
+                        writeLog("messageFontWeight : \(appvars.messageFontWeight)")
                     case "colour","color":
-                        appvars.messageFontColour = stringToColour(item[1])
-                                                writeLog("messageFontColour : \(appvars.messageFontColour)")
+                        appvars.messageFontColour = Color(argument: item[1])
+                        writeLog("messageFontColour : \(appvars.messageFontColour)")
                     case "name":
                         appvars.messageFontName = item[1]
-                                                writeLog("messageFontName : \(appvars.messageFontName)")
+                        writeLog("messageFontName : \(appvars.messageFontName)")
                     default:
-                                                writeLog("Unknown paramater \(item[0])")
+                        writeLog("Unknown paramater \(item[0])")
                 }
             }
         }

--- a/dialog/Functions/Strings.swift
+++ b/dialog/Functions/Strings.swift
@@ -9,13 +9,6 @@ import Foundation
 import CryptoKit
 import SwiftUI
 
-func hashForString(_ string: String) -> String {
-    // Returns a sha256 hash of the given text
-    let inputData = Data(string.utf8)
-    let hashed = SHA256.hash(data: inputData)
-    return hashed.compactMap { String(format: "%02x", $0) }.joined()
-}
-
 func string2float(string: String, defaultValue: CGFloat = 0) -> CGFloat {
     // take a umber in scring format and return a float
     let numberFormatter = NumberFormatter()
@@ -46,77 +39,3 @@ func getVersionString() -> String {
     return appVersion
 }
 
-func stringToColour(_ colourValue: String) -> Color {
-    // convert a colour from a string representation to Color
-    var returnColor: Color
-
-    if isValidColourHex(colourValue) {
-
-        let colourRedValue = "\(colourValue[1])\(colourValue[2])"
-        let colourRed = Double(Int(colourRedValue, radix: 16)!)/255
-
-        let colourGreenValue = "\(colourValue[3])\(colourValue[4])"
-        let colourGreen = Double(Int(colourGreenValue, radix: 16)!)/255
-
-        let colourBlueValue = "\(colourValue[5])\(colourValue[6])"
-        let colourBlue = Double(Int(colourBlueValue, radix: 16)!)/255
-
-        returnColor = Color(red: colourRed, green: colourGreen, blue: colourBlue)
-
-    } else {
-        switch colourValue {
-
-        case "accent":
-            returnColor = Color.accentColor
-        case "black":
-            returnColor = Color.black
-        case "blue":
-            returnColor = Color.blue
-        case "gray":
-            returnColor = Color.gray
-        case "green":
-            returnColor = Color.green
-        case "orange":
-            returnColor = Color.orange
-        case "pink":
-            returnColor = Color.pink
-        case "purple":
-            returnColor = Color.purple
-        case "red":
-            returnColor = Color.red
-        case "white":
-            returnColor = Color.white
-        case "yellow":
-            returnColor = Color.yellow
-        case "mint":
-            returnColor = Color.mint
-        case "cyan":
-            returnColor = Color.cyan
-        case "indigo":
-            returnColor = Color.indigo
-        case "teal":
-            returnColor = Color.teal
-        default:
-            returnColor = Color.primary
-        }
-    }
-
-    return returnColor
-
-}
-
-func colourToString(color: Color) -> String {
-    let components = color.cgColor?.components
-    let red: CGFloat = components?[0] ?? 0.0
-    let green: CGFloat = components?[1] ?? 0.0
-    let blue: CGFloat = components?[2] ?? 0.0
-
-    let hexString = String.init(format: "#%02lX%02lX%02lX", lroundf(Float(red * 255)), lroundf(Float(green * 255)), lroundf(Float(blue * 255)))
-    return hexString
- }
-
-func isValidColourHex(_ hexvalue: String) -> Bool {
-    let hexRegEx = "^#([a-fA-F0-9]{6})$"
-    let hexPred = NSPredicate(format: "SELF MATCHES %@", hexRegEx)
-    return hexPred.evaluate(with: hexvalue)
-}

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -195,32 +195,6 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "", observedObject: Dial
     exit(exitCode)
 }
 
-func textToFontWeight(_ weight: String) -> Font.Weight {
-    switch weight {
-        case "bold":
-            return Font.Weight.bold
-        case "heavy":
-            return Font.Weight.heavy
-        case "light":
-            return Font.Weight.light
-        case "medium":
-            return Font.Weight.medium
-        case "regular":
-            return Font.Weight.regular
-        case "thin":
-            return Font.Weight.thin
-        default:
-            return Font.Weight.thin
-    }
-}
-
-func plistFromData(_ data: Data) throws -> [String: Any] {
-    try PropertyListSerialization.propertyList(
-        from: data,
-        format: nil
-    ) as! [String: Any]
-}
-
 func isDNDEnabled() -> Bool {
     // check for DND and return true if it is on
 

--- a/dialog/Views/ConstructionKit/ConstructionKitView.swift
+++ b/dialog/Views/ConstructionKit/ConstructionKitView.swift
@@ -89,11 +89,11 @@ struct JSONView: View {
 
         // message font stuff
         if observedDialogContent.appProperties.messageFontColour != .primary {
-            json[appArguments.messageFont.long].dictionaryObject = ["colour": colourToString(color: observedDialogContent.appProperties.messageFontColour)]
+            json[appArguments.messageFont.long].dictionaryObject = ["colour": observedDialogContent.appProperties.messageFontColour.hexValue]
         }
 
         if observedDialogContent.appProperties.titleFontColour != .primary {
-            json[appArguments.titleFont.long].dictionaryObject = ["colour": colourToString(color: observedDialogContent.appProperties.titleFontColour)]
+            json[appArguments.titleFont.long].dictionaryObject = ["colour": observedDialogContent.appProperties.titleFontColour.hexValue]
         }
 
         // convert the JSON to a raw String

--- a/dialog/Views/IconView.swift
+++ b/dialog/Views/IconView.swift
@@ -72,7 +72,7 @@ struct IconView: View {
                     SFValues = SFValues.map { $0.trimmingCharacters(in: .whitespaces) }
                     for value in SFValues where value.hasPrefix("bgcolo") {
                         if let bgColour = value.components(separatedBy: "=").last {
-                            sfBackgroundIconColour = stringToColour(bgColour)
+                            sfBackgroundIconColour = Color(argument: bgColour)
                         }
                     }
                     overlayImageBackground = true
@@ -138,7 +138,7 @@ struct IconView: View {
                     case "sf":
                         builtInIconName = SFArgValue
                     case "weight":
-                        builtInIconWeight = textToFontWeight(SFArgValue)
+                            builtInIconWeight = Font.Weight(argument: SFArgValue)
                     case _ where SFArg.hasPrefix("colo"):
                         if SFArgValue == "auto" {
                             // detecting sf symbol properties seems to be annoying, at least in swiftui 2
@@ -151,11 +151,11 @@ struct IconView: View {
                             iconRenderingMode = Image.TemplateRenderingMode.template // switches to monochrome which allows us to tint the sf symbol
                             if SFArg.hasSuffix("2") {
                                 sfGradientPresent = true
-                                builtInIconSecondaryColour = stringToColour(SFArgValue)
+                                builtInIconSecondaryColour = Color(argument: SFArgValue)
                             } else if SFArg.hasSuffix("3") {
-                                builtInIconTertiaryColour = stringToColour(SFArgValue)
+                                builtInIconTertiaryColour = Color(argument: SFArgValue)
                             } else {
-                                builtInIconColour = stringToColour(SFArgValue)
+                                builtInIconColour = Color(argument: SFArgValue)
                             }
                         }
                     case "palette":
@@ -166,11 +166,11 @@ struct IconView: View {
                         for index in 0...paletteColours.count-1 {
                             switch index {
                             case 0:
-                                builtInIconColour = stringToColour(paletteColours[index])
+                                builtInIconColour = Color(argument: paletteColours[index])
                             case 1:
-                                builtInIconSecondaryColour = stringToColour(paletteColours[index])
+                                builtInIconSecondaryColour = Color(argument: paletteColours[index])
                             case 2:
-                                builtInIconTertiaryColour = stringToColour(paletteColours[index])
+                                builtInIconTertiaryColour = Color(argument: paletteColours[index])
                             default: ()
                             }
                         }

--- a/dialog/Views/TextEntryView.swift
+++ b/dialog/Views/TextEntryView.swift
@@ -106,7 +106,7 @@ struct TextEntryView: View {
                                                 userInputState.textFields[index].value = textContent
                                             })
                                         Image(systemName: "lock.fill")
-                                            .foregroundColor(stringToColour("#008815")).opacity(0.5)
+                                            .foregroundColor(Color(argument: "#008815")).opacity(0.5)
                                             .frame(idealWidth: fieldwidth*0.50, maxWidth: 350, alignment: .trailing)
                                     }
                                 } else {


### PR DESCRIPTION
## Add Option Values for Missing System Constants

### Colors
- `'brown'` (`Color.brown`)
- `'primary'` (`Color.primary`)
- `'secondary'` (`Color.secondary`)

### Font Weights
- `'ultralight'` (`Font.Weight.ultraLight`)
- `'semibold'`  (`Font.Weight.semibold`)
- `'black'`  (`Font.Weight.black`)

## Enhance Extensions with Utility Logic

### Font.Weight
- Add `init(argument:)`.
    - Relocates `textToFontWeight(_:)` utility function.

### Color
- Add `init(argument:)`.
    - Relocates `stringToColour(_:)` utility function. 
- Add `var hexValue`.
    - Relocates `colourToString(color:)` utility function.
 
### String
- Add `var sha256Hash`.
    - Relocates `hashForString(_:)` utility function.
