### PR TITLE
Dev 2.4.1

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -899,7 +899,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -928,7 +928,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/MarkdownUI",
       "state" : {
-        "revision" : "12b351a75201a8124c2f2e1f9fc6ef5cd812c0b9",
-        "version" : "2.1.0"
+        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
+        "version" : "6.0.0"
       }
     },
     {

--- a/dialog.xcodeproj/xcshareddata/xcschemes/Dialog App Bundle.xcscheme
+++ b/dialog.xcodeproj/xcshareddata/xcschemes/Dialog App Bundle.xcscheme
@@ -57,6 +57,10 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--listitem &quot;test1&quot;,icon=&quot;sf=applelogo&quot;,status=wait,subtitle=&quot;Here is a sub title. Here is a sub title. Here is a sub title. Here is a sub title. Here is a sub title. Here is a sub title. &quot; --icon sf=applelogo --listitem &quot;test 2&quot;,icon=&quot;sf=applelogo&quot;,status=progress"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--jsonstring &apos;{&quot;listitem&quot; : [{&quot;title&quot; : &quot;Item One&quot;, &quot;icon&quot; : &quot;/path/to/image&quot;, &quot;status&quot; : &quot;pending&quot;, &quot;statustext&quot; : &quot;Pending&quot;},{&quot;title&quot; : &quot;Item Two&quot;, &quot;icon&quot; : &quot;/path/to/image&quot;, &quot;status&quot; : &quot;pending&quot;, &quot;statustext&quot; : &quot;Pending&quot;}]}&apos;"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct AppVariables {
 
-    var cliversion                      = "2.4.0"
+    var cliversion                      = "2.4.1"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -149,5 +149,6 @@ struct CommandLineArguments {
     var windowButtonsEnabled     = CommandlineArgument(long: "windowbuttons")
     var windowResizable          = CommandlineArgument(long: "resizable", isbool: true)
     var showOnAllScreens         = CommandlineArgument(long: "showonallscreens", isbool: true)
+    var notificationGoPing       = CommandlineArgument(long: "enablenotificationsounds", isbool: true)
     var hideDefaultKeyboardAction = CommandlineArgument(long: "hidedefaultkeyboardaction", isbool: true)
 }

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -148,5 +148,6 @@ struct CommandLineArguments {
     var eulaMode                 = CommandlineArgument(long: "eula", isbool: true)
     var windowButtonsEnabled     = CommandlineArgument(long: "windowbuttons")
     var windowResizable          = CommandlineArgument(long: "resizable", isbool: true)
+    var showOnAllScreens         = CommandlineArgument(long: "showonallscreens", isbool: true)
     var hideDefaultKeyboardAction = CommandlineArgument(long: "hidedefaultkeyboardaction", isbool: true)
 }

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -13,7 +13,7 @@ struct SDHelp {
     public func printHelpShort() {
         writeLog("Printing short help")
         print("swiftDialog v\(getVersionString())")
-        print("©2023 Bart Reardon\n")
+        print("©2024 Bart Reardon\n")
         print("\n use --help <option> for more details\n")
         let mirror = Mirror(reflecting: argument)
         for child in mirror.children {

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -863,6 +863,14 @@ struct SDHelp {
         This option also implies the --\(argument.movableWindow.long) flag
 """
 
+        argument.showOnAllScreens.helpShort = "Enable the dialog window to appear on all screens"
+        argument.showOnAllScreens.helpUsage = ""
+        argument.showOnAllScreens.helpLong = """
+        Dialog windows will appear on all screens, even on top of fullscreen applications
+
+        This property is implied when using --\(argument.forceOnTop.long)
+"""
+
         argument.getVersion.helpShort = "Print version string"
         argument.getVersion.helpUsage = ""
         argument.getVersion.helpLong = ""

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -111,7 +111,9 @@ func processCLOptions(json: JSON = getJSON()) {
     appArguments.messageOption.value = appArguments.messageOption.value
                                         .replacingOccurrences(of: "<br>", with: "  \n")
                                         .replacingOccurrences(of: "<hr>", with: "****")
-
+    if !appArguments.messageOption.present {
+        appArguments.messageOption.value = appvars.messageDefault
+    }
     if appArguments.messageOption.present && appArguments.messageOption.value.lowercased().hasSuffix(".md") {
         appArguments.messageOption.value = getMarkdown(mdFilePath: appArguments.messageOption.value)
     }
@@ -706,6 +708,7 @@ func processCLOptions(json: JSON = getJSON()) {
     }
 
     if appArguments.forceOnTop.present {
+        appArguments.showOnAllScreens.present = true
         appvars.windowOnTop = true
         writeLog("windowOnTop = true")
     }
@@ -781,7 +784,7 @@ func processCLOptionValues() {
     appArguments.titleFont.evaluate(json: json)
 
     // message
-    appArguments.messageOption.evaluate(json: json, defaultValue: appvars.messageDefault)
+    appArguments.messageOption.evaluate(json: json)
     appArguments.messageAlignment.evaluate(json: json, defaultValue: appvars.messageAlignmentTextRepresentation)
     appArguments.messageAlignmentOld.evaluate(json: json, defaultValue: appvars.messageAlignmentTextRepresentation)
     if appArguments.messageAlignmentOld.present {
@@ -816,6 +819,9 @@ func processCLOptionValues() {
         (appvars.windowPositionVertical,appvars.windowPositionHorozontal) = windowPosition(appArguments.position.value)
     }
     appArguments.positionOffset.evaluate(json: json, defaultValue: "\(appvars.windowPositionOffset)")
+    if appArguments.positionOffset.present {
+        appvars.windowPositionOffset = appArguments.positionOffset.value.floatValue()
+    }
 
     // window properties
     appArguments.windowWidth.evaluate(json: json)
@@ -925,6 +931,7 @@ func processCLOptionValues() {
     appArguments.cautionIcon.evaluate(json: json)
     appArguments.movableWindow.evaluate(json: json)
     appArguments.forceOnTop.evaluate(json: json)
+    appArguments.showOnAllScreens.evaluate(json: json)
     appArguments.smallWindow.evaluate(json: json)
     appArguments.bigWindow.evaluate(json: json)
     appArguments.fullScreenWindow.evaluate(json: json)

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -947,6 +947,7 @@ func processCLOptionValues() {
     appArguments.constructionKit.evaluate(json: json)
     appArguments.miniMode.evaluate(json: json)
     appArguments.notification.evaluate(json: json)
+    appArguments.notificationGoPing.evaluate(json: json)
     appArguments.eulaMode.evaluate(json: json)
     appArguments.windowResizable.evaluate(json: json)
 

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -50,7 +50,8 @@ func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
                          acceptString: acceptActionLabel,
                          acceptAction: arguments.button1ActionOption.value,
                          declineString: declineActionLabel,
-                         declineAction: arguments.button2ActionOption.value)
+                         declineAction: arguments.button2ActionOption.value,
+                         notificationSoundEnabled: arguments.notificationGoPing.present)
         usleep(100000)
     }
     return arguments.notification.present
@@ -63,7 +64,8 @@ func sendNotification(title: String = "",
                       acceptString: String = "Open",
                       acceptAction: String = "",
                       declineString: String = "Close",
-                      declineAction: String = "") {
+                      declineAction: String = "",
+                      notificationSoundEnabled: Bool = false) {
     let notification = UNUserNotificationCenter.current()
     let tempImagePath: String = "/var/tmp/sdnotification.png"
     // Define the custom actions.
@@ -75,8 +77,11 @@ func sendNotification(title: String = "",
         options: [])
     var actions: [UNNotificationAction] = []
 
-    if !acceptString.isEmpty && !declineString.isEmpty {
-        actions = [acceptActionLabel, declineActionLabel]
+    if !acceptString.isEmpty {
+        actions.append(acceptActionLabel)
+    }
+    if !declineString.isEmpty {
+        actions.append(declineActionLabel)
     }
 
     if !image.isEmpty {
@@ -120,7 +125,9 @@ func sendNotification(title: String = "",
                 content.userInfo = ["ACCEPT_ACTION": acceptAction,
                                 "DECLINE_ACTION": declineAction ]
                 content.categoryIdentifier = "SD_NOTIFICATION"
-                content.sound = UNNotificationSound.default
+                if notificationSoundEnabled {
+                    content.sound = UNNotificationSound.default
+                }
                 content.attachments = []
                 // Add any Attachments
                 if !image.isEmpty {

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -29,12 +29,12 @@ func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
     // check if we are sending a notification
     if arguments.notification.present {
         writeLog("Sending a notification")
-        /*
+
         var notificationIcon = ""
         if appArguments.iconOption.present {
             notificationIcon = appArguments.iconOption.value
         }
-         */
+
         var acceptActionLabel: String = ""
         var declineActionLabel: String = ""
         if arguments.button1TextOption.present {
@@ -46,6 +46,7 @@ func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
         sendNotification(title: arguments.titleOption.value,
                          subtitle: arguments.subTitleOption.value,
                          message: arguments.messageOption.value,
+                         image: notificationIcon,
                          acceptString: acceptActionLabel,
                          acceptAction: arguments.button1ActionOption.value,
                          declineString: declineActionLabel,
@@ -58,33 +59,53 @@ func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
 func sendNotification(title: String = "",
                       subtitle: String = "",
                       message: String = "",
+                      image: String = "",
                       acceptString: String = "Open",
                       acceptAction: String = "",
                       declineString: String = "Close",
                       declineAction: String = "") {
     let notification = UNUserNotificationCenter.current()
+    let tempImagePath: String = "/var/tmp/sdnotification.png"
     // Define the custom actions.
     let acceptActionLabel = UNNotificationAction(identifier: "ACCEPT_ACTION_LABEL",
-          title: acceptString,
-          options: [])
+        title: acceptString,
+        options: [])
     let declineActionLabel = UNNotificationAction(identifier: "DECLINE_ACTION_LABEL",
-          title: declineString,
-          options: [])
+        title: declineString,
+        options: [])
     var actions: [UNNotificationAction] = []
 
     if !acceptString.isEmpty && !declineString.isEmpty {
         actions = [acceptActionLabel, declineActionLabel]
     }
 
+    if !image.isEmpty {
+        // default image just in case
+        var importedImage: NSImage = NSImage(systemSymbolName: "applelogo", accessibilityDescription: "Apple logo")!
+
+        if image.hasSuffix(".app") || image.hasSuffix("prefPane") {
+            importedImage = getAppIcon(appPath: image)
+        } else if image.lowercased().hasPrefix("sf=") {
+            let imageConfig = NSImage.SymbolConfiguration(pointSize: 128, weight: .thin)
+            importedImage = NSImage(systemSymbolName: String(image.dropFirst(3)), accessibilityDescription: "SF Symbol")!
+                .withSymbolConfiguration(imageConfig)!
+        } else {
+            importedImage = getImageFromPath(fileImagePath: image, returnErrorImage: true)
+        }
+
+        // need to save a temp version of the image for the notification to be able to load it
+        savePNG(image: importedImage, path: tempImagePath)
+    }
+
     // Define the notification type
-    let meetingInviteCategory =
+    let sdCategory =
           UNNotificationCategory(identifier: "SD_NOTIFICATION",
           actions: actions,
           intentIdentifiers: [],
           hiddenPreviewsBodyPlaceholder: "",
                                  options: .customDismissAction)
 
-    notification.setNotificationCategories([meetingInviteCategory])
+    notification.setNotificationCategories([sdCategory])
 
     notification.getNotificationSettings { settings in
         guard (settings.authorizationStatus == .authorized) ||
@@ -99,6 +120,18 @@ func sendNotification(title: String = "",
                 content.userInfo = ["ACCEPT_ACTION": acceptAction,
                                 "DECLINE_ACTION": declineAction ]
                 content.categoryIdentifier = "SD_NOTIFICATION"
+                content.sound = UNNotificationSound.default
+                content.attachments = []
+                // Add any Attachments
+                if !image.isEmpty {
+                    do {
+                        let fileURL = URL(fileURLWithPath: tempImagePath)
+                        let attachment = try UNNotificationAttachment(identifier: "AttachedContent", url: fileURL, options: .none)
+                        content.attachments = [attachment]
+                    } catch let error {
+                        writeLog(error.localizedDescription, logLevel: .error)
+                    }
+                }
 
                 // Create the request
                 //let uuidString = UUID().uuidString

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4750</string>
+	<string>4753</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -577,7 +577,7 @@ class DialogUpdatableContent: ObservableObject {
     @Published var showSheet: Bool
     @Published var sheetErrorMessage: String
 
-    @Published var blurredScreen = [BlurWindowController]()
+    //@Published var blurredScreen = [BlurWindowController]()
 
     @Published var updateView: Bool = true
 

--- a/dialog/Views/DialogView.swift
+++ b/dialog/Views/DialogView.swift
@@ -66,6 +66,7 @@ struct DialogView: View {
                             .padding(.leading, observedData.appProperties.sidePadding+10)
                             .padding(.trailing, observedData.iconSize/10)
                         }
+                        Spacer()
                         MessageContent(observedDialogContent: observedData)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                     }

--- a/dialog/Views/ListView.swift
+++ b/dialog/Views/ListView.swift
@@ -59,7 +59,7 @@ struct ListView: View {
             default: ()
             }
         }
-        for item in userInputState.listItems where item.subTitle != "" {
+        for item in userInputState.listItems where !item.subTitle.isEmpty {
             rowHeight += 28
             subtitlePresent = true
             break
@@ -71,93 +71,82 @@ struct ListView: View {
         if observedData.args.listItem.present {
             let _ = writeLog("Displaying listitems")
             ScrollViewReader { proxy in
-                GeometryReader { geometry in
-                    let listHeightPadding = ((geometry.size.height/CGFloat(userInputState.listItems.count)/2) * proportionalListHeight)
-                //withAnimation(.default) {
-                    VStack {
-                        List(0..<userInputState.listItems.count, id: \.self) {index in
-                                HStack {
-                                    if userInputState.listItems[index].icon != "" {
-                                        let _ = writeLog("Switch index \(index): Displaying icon \(userInputState.listItems[index].icon)")
-                                        VStack {
-                                            IconView(image: userInputState.listItems[index].icon, overlay: "", sfPaddingEnabled: false)
-                                                .frame(maxWidth: rowHeight, maxHeight: rowHeight)
-                                                .frame(width: rowHeight)
-                                        }
-                                    }
-                                    VStack {
-                                        HStack {
-                                            Text(userInputState.listItems[index].title)
-                                                .font(.system(size: rowFontSize))
-                                                .id(index)
-                                            Spacer()
-                                            /*
-                                            if userInputState.listItems[index].statusText != "" {
-                                                Text(userInputState.listItems[index].statusText)
-                                                    .font(.system(size: rowFontSize))
-                                                    .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
-                                            }
-                                             */
-                                        }
-                                        if subtitlePresent {
-                                            HStack {
-                                                Text(userInputState.listItems[index].subTitle)
-                                                    .lineLimit(2)
-                                                    .font(.system(size: rowFontSize-4))
-                                                    .foregroundStyle(.secondary)
-                                                    //.padding(.top, 1)
-                                                Spacer()
-                                            }
-                                        }
-                                    }
-                                    Spacer()
+                VStack {
+                    List(0..<userInputState.listItems.count, id: \.self) {index in
+                        VStack {
+                            HStack {
+                                if !userInputState.listItems[index].icon.isEmpty {
+                                    let _ = writeLog("Switch index \(index): Displaying icon \(userInputState.listItems[index].icon)")
+                                    IconView(image: userInputState.listItems[index].icon, overlay: "", sfPaddingEnabled: false)
+                                        .frame(maxHeight: rowHeight)
+                                        .frame(width: rowHeight)
+                                }
+                                VStack {
                                     HStack {
-                                        if userInputState.listItems[index].statusText != "" {
-                                            Text(userInputState.listItems[index].statusText)
-                                                .font(.system(size: rowFontSize))
-                                                .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
-                                        }
-
-                                        switch userInputState.listItems[index].statusIcon {
-                                        case "progress":
-                                            ProgressView("", value: userInputState.listItems[index].progress, total: 100)
-                                                .progressViewStyle(CirclerPercentageProgressViewStyle())
-                                                .frame(width: rowStatusHeight, height: rowStatusHeight-5)
-                                                .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
-                                        case "wait":
-                                            ProgressView()
-                                                .progressViewStyle(.circular)
-                                                .scaleEffect(0.8, anchor: .trailing)
-                                                .frame(height: rowStatusHeight)
-                                                .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
-                                        case "success":
-                                            StatusImage(name: "checkmark.circle.fill", colour: .green, size: rowStatusHeight)
-                                        case "fail":
-                                            StatusImage(name: "xmark.circle.fill", colour: .red, size: rowStatusHeight)
-                                        case "pending":
-                                            StatusImage(name: "ellipsis.circle.fill", colour: .gray, size: rowStatusHeight)
-                                        case "error":
-                                            StatusImage(name: "exclamationmark.circle.fill", colour: .yellow, size: rowStatusHeight)
-                                        default:
-                                            EmptyView()
+                                        Text(userInputState.listItems[index].title)
+                                            .font(.system(size: rowFontSize))
+                                            .id(index)
+                                        Spacer()
+                                    }
+                                    if subtitlePresent {
+                                        HStack {
+                                            Text(userInputState.listItems[index].subTitle)
+                                                .lineLimit(2)
+                                                .font(.system(size: rowFontSize-4))
+                                                .foregroundStyle(.secondary)
+                                            //.padding(.top, 1)
+                                            Spacer()
                                         }
                                     }
                                 }
-                                .frame(height: rowHeight+listHeightPadding)
-                                Divider()
-                        }
-                        .background(Color("editorBackgroundColour"))
-                        .listStyle(SidebarListStyle())
-                    }
-                    .onChange(of: observedData.listItemUpdateRow, perform: { _ in
-                        DispatchQueue.main.async {
-                            withAnimation(.easeInOut(duration: 0.5)) {
-                                proxy.scrollTo(observedData.listItemUpdateRow)
+                                Spacer()
+                                HStack {
+                                    if userInputState.listItems[index].statusText != "" {
+                                        Text(userInputState.listItems[index].statusText)
+                                            .font(.system(size: rowFontSize))
+                                            .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
+                                    }
+
+                                    switch userInputState.listItems[index].statusIcon {
+                                    case "progress":
+                                        ProgressView("", value: userInputState.listItems[index].progress, total: 100)
+                                            .progressViewStyle(CirclerPercentageProgressViewStyle())
+                                            .frame(width: rowStatusHeight, height: rowStatusHeight-5)
+                                            .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
+                                    case "wait":
+                                        ProgressView()
+                                            .progressViewStyle(.circular)
+                                            .scaleEffect(0.8, anchor: .trailing)
+                                            .frame(height: rowStatusHeight)
+                                            .transition(AnyTransition.opacity.animation(.easeInOut(duration: 0.2)))
+                                    case "success":
+                                        StatusImage(name: "checkmark.circle.fill", colour: .green, size: rowStatusHeight)
+                                    case "fail":
+                                        StatusImage(name: "xmark.circle.fill", colour: .red, size: rowStatusHeight)
+                                    case "pending":
+                                        StatusImage(name: "ellipsis.circle.fill", colour: .gray, size: rowStatusHeight)
+                                    case "error":
+                                        StatusImage(name: "exclamationmark.circle.fill", colour: .yellow, size: rowStatusHeight)
+                                    default:
+                                        EmptyView()
+                                    }
+                                }
                             }
+                            .frame(maxHeight: rowHeight)
+                            Divider()
                         }
-                    })
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .background(Color("editorBackgroundColour"))
+                    .listStyle(SidebarListStyle())
                 }
+                .onChange(of: observedData.listItemUpdateRow, perform: { _ in
+                    DispatchQueue.main.async {
+                        withAnimation(.easeInOut(duration: 0.5)) {
+                            proxy.scrollTo(observedData.listItemUpdateRow)
+                        }
+                    }
+                })
+                .clipShape(RoundedRectangle(cornerRadius: 8))
             }
         }
     }

--- a/dialog/Views/MessageContentView.swift
+++ b/dialog/Views/MessageContentView.swift
@@ -105,7 +105,7 @@ struct MessageContent: View {
                 if !observedData.args.messageVerticalAlignment.present || ["centre", "center", "top"].contains(observedData.args.messageVerticalAlignment.value) {
                     Spacer()
                 }
-            }
+            } 
 
             Group {
                 TextFileView(logFilePath: observedData.args.logFileToTail.value)


### PR DESCRIPTION
Fixes:

 - listitem spacing should be back to how it appeared pre 2.4.0 #345 
 - dialog windows should display properly on all spaces, including fullscreen apps when using `--ontop`
 - when using a blank or null `--message ""`, it should now be blank and not default to the boilerplate text 
 - images used in notifications (when specified with `--icon` which gets attached as an image) should work again
 - notifications can now trigger the default notification sound with `--enablenotificationsounds`
 - notification with a single action will now show the button label on hover