### PR TITLE
Adds 'stack' style for buttons

### DIFF
--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -167,9 +167,12 @@ struct SDHelp {
 """
 
         argument.buttonStyle.helpShort = "Configure how the button area is displayed"
-        argument.buttonStyle.helpUsage = "center|centre"
+        argument.buttonStyle.helpUsage = "center|centre|stack"
         argument.buttonStyle.helpLong = """
-        Displays the buttons centered at the bottom of the window
+        Displays the buttons the bottom of the window, in style indicated.
+
+        "center|centre" will display the buttons at the bottom center.
+        "stack" will display full width buttons in a vertical stack with additional padding.
 
         When using this mode, --\(argument.timerBar.long) and --\(argument.infoButtonOption.long) are not available
 """

--- a/dialog/Views/ButtonView.swift
+++ b/dialog/Views/ButtonView.swift
@@ -72,6 +72,35 @@ struct ButtonView: View {
                 Spacer()
                     .frame(width: 20)
             }
+        }
+        else if ["stack"].contains(observedData.args.buttonStyle.value) {
+            VStack {
+                if !(observedData.args.button1TextOption.value == "none") {
+                    Button(action: {
+                        buttonAction(action: self.button1action, exitCode: 0, executeShell: self.buttonShellAction, observedObject: observedData)
+
+                    }, label: {
+                        Text(observedData.args.button1TextOption.value)
+                            .frame(minWidth: 50, maxWidth: .infinity, alignment: .center)
+                            .padding(5)
+                    }
+                    )
+                    .keyboardShortcut(observedData.appProperties.button1DefaultAction)
+                    .disabled(observedData.args.button1Disabled.present)
+                }
+                
+                if observedData.args.button2Option.present || observedData.args.button2TextOption.present {
+                    Button(action: {
+                        quitDialog(exitCode: observedData.appProperties.exit2.code, observedObject: observedData)
+                    }, label: {
+                        Text(observedData.args.button2TextOption.value)
+                            .frame(minWidth: 50, maxWidth: .infinity, alignment: .center)
+                            .padding(5)
+                    }
+                    )
+                    .keyboardShortcut(observedData.appProperties.button2DefaultAction)
+                }
+            }
         } else {
             // Buttons
             HStack {


### PR DESCRIPTION
Adds an additional _stack_ style for buttons, which displays the buttons full width in a vertical stack.  A slight amount of padding was added to mimic macOS native dialogs with stacked buttons.

 Similar to the _center_ style, the new _stack_ style would also disable `--timer` and `--infobutton`.