### PR TITLE
Support for showing dialog windows at the loginwindow

### DIFF
--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -150,5 +150,6 @@ struct CommandLineArguments {
     var windowResizable          = CommandlineArgument(long: "resizable", isbool: true)
     var showOnAllScreens         = CommandlineArgument(long: "showonallscreens", isbool: true)
     var notificationGoPing       = CommandlineArgument(long: "enablenotificationsounds", isbool: true)
+    var loginWindow              = CommandlineArgument(long: "loginwindow", isbool: true)
     var hideDefaultKeyboardAction = CommandlineArgument(long: "hidedefaultkeyboardaction", isbool: true)
 }

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -871,6 +871,14 @@ struct SDHelp {
         This property is implied when using --\(argument.forceOnTop.long)
 """
 
+        argument.loginWindow.helpShort = "Enable the dialog window to be shown at login"
+        argument.loginWindow.helpUsage = ""
+        argument.loginWindow.helpLong = """
+        Enables the dialog window to be shown at login.
+
+        This option also implies the --\(argument.forceOnTop.long) flag
+"""
+
         argument.getVersion.helpShort = "Print version string"
         argument.getVersion.helpUsage = ""
         argument.getVersion.helpLong = ""

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -950,6 +950,7 @@ func processCLOptionValues() {
     appArguments.notificationGoPing.evaluate(json: json)
     appArguments.eulaMode.evaluate(json: json)
     appArguments.windowResizable.evaluate(json: json)
+    appArguments.loginWindow.evaluate(json: json)
 
     // command line only options
     appArguments.listFonts.evaluate()

--- a/dialog/Views/BackgroundBlur.swift
+++ b/dialog/Views/BackgroundBlur.swift
@@ -26,6 +26,9 @@ class BlurWindowController: NSWindowController {
         self.window?.contentViewController = BlurViewController()
         self.window?.setFrame((allScreens.frame), display: true)
         self.window?.collectionBehavior = [.canJoinAllSpaces]
+        if appArguments.loginWindow.present {
+            self.window?.canBecomeVisibleWithoutLogin = true
+        }
     }
 }
 

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -58,9 +58,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             if appArguments.showOnAllScreens.present {
                 window.collectionBehavior = [.canJoinAllSpaces]
             }
+            if appArguments.loginWindow.present {
+                window.canBecomeVisibleWithoutLogin = true
+                writeLog("Window can appear at the loginwindow", logLevel: .debug)
+            }
 
             // Set window level
-            if appArguments.forceOnTop.present || appArguments.blurScreen.present {
+            if appArguments.forceOnTop.present || appArguments.blurScreen.present || appArguments.loginWindow.present {
                 window.level = .floating
                 writeLog("Window is forced on top", logLevel: .debug)
             } else {


### PR DESCRIPTION
Adds support for showing dialog windows at the loginwindow with `--loginwindow`. Dialog still needs to be launched by a LoginWindow launch agent as described [here](https://github.com/fabienconus/zerouser/blob/main/zerotouch_zerouser_deployment.md)