### PR TITLE
explicitly use spaces instead of tabs

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -246,7 +246,9 @@
 				4114E1E727153FEE00388274 /* Frameworks */,
 				4156C21B29F6A1F7003F04DF /* Dialog copy-Info.plist */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 			usesTabs = 0;
 		};
 		4154C2DB25F76BDB00A3D373 /* Products */ = {

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 				4156C21B29F6A1F7003F04DF /* Dialog copy-Info.plist */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		4154C2DB25F76BDB00A3D373 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
For folks whose Xcode is defaulted to using tabs for indentation (sorry!), this setting forces spaces over tabs explicitly at the top of the project to match how the project is indented