### PR TITLE
Imply ontop when using loginwindow

### DIFF
--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -731,6 +731,10 @@ func processCLOptions(json: JSON = getJSON()) {
         writeLog("windowIsMoveable = true")
     }
 
+    if appArguments.loginWindow.present {
+        appArguments.forceOnTop.present = true
+    }
+
     if appArguments.forceOnTop.present {
         appArguments.showOnAllScreens.present = true
         appvars.windowOnTop = true

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -69,7 +69,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             }
 
             // Set window level
-            if appArguments.forceOnTop.present || appArguments.blurScreen.present || appArguments.loginWindow.present {
+            if appArguments.forceOnTop.present || appArguments.blurScreen.present {
                 window.level = .floating
                 writeLog("Window is forced on top", logLevel: .debug)
             } else {


### PR DESCRIPTION
Simplifies loginwindow option by fully implying ontop. Fixes focus and window level issues