### PR TITLE
swiftDialog 2.5.4

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -914,7 +914,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.5.3;
+				MARKETING_VERSION = 2.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -943,7 +943,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.5.3;
+				MARKETING_VERSION = 2.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AppDefaults {
-    let cliversion                      = "2.5.3"
+    let cliversion                      = "2.5.4"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -168,7 +168,11 @@ extension CommandlineArgument {
             if let numberValue = json[self.long].number {
                 self.value = numberValue.stringValue
             } else {
-                self.value = json[self.long].string ?? CLOptionText(optionName: self)
+                var stringValue = json[self.long].string ?? CLOptionText(optionName: self)
+                if stringValue == "" {
+                    stringValue = "none"
+                }
+                self.value = stringValue
             }
         }
 

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -81,6 +81,12 @@ func processCLOptionValues() {
     // this method reads in arguments from either json file or from the command line and loads them into the appArguments object
     // also records whether an argument is present or not
     writeLog("Checking command line options for arguments")
+    // if argument count is < 2 print help and exit
+    if CommandLine.arguments.count < 2 {
+        SDHelp(arguments: appArguments).printHelpShort()
+        quitDialog(exitCode: 0)
+    }
+    writeLog("Argument count: \(CommandLine.arguments.count)", logLevel: .debug)
     for argument in CommandLine.arguments {
         writeLog("Using argument: \(argument)", logLevel: .debug)
     }

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -17,6 +17,7 @@ func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent noti
 }
 
 func checkNotificationAuthorisation(notificationPresent: Bool) {
+    writeLog("Checking notification request authorization", logLevel: .debug)
     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, error in
         if let error = error {
             if notificationPresent {

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4784</string>
+	<string>4792</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Views/MessageContentView.swift
+++ b/dialog/Views/MessageContentView.swift
@@ -44,13 +44,23 @@ struct MessageContent: View {
             if observedData.args.centreIcon.present && observedData.args.iconOption.present {
                 HStack {
                     Spacer()
-                    ForEach(0..<userInputState.iconItems.count, id: \.self) {index in
-                        IconView(image: userInputState.iconItems[index].value,
-                                 alpha: observedData.iconAlpha)
-                        .frame(height: iconDisplayWidth, alignment: .top)
-                        .border(observedData.appProperties.debugBorderColour, width: 2)
-                        .accessibilityHint(observedData.args.iconAccessabilityLabel.value)
+                    HStack {
+                        if userInputState.iconItems.count == 1 {
+                            IconView(image: observedData.args.iconOption.value,
+                                     overlay: observedData.args.overlayIconOption.value,
+                                     alpha: observedData.iconAlpha)
+                            .frame(width: iconDisplayWidth, alignment: .top)
+                        } else {
+                            ForEach(0..<userInputState.iconItems.count, id: \.self) {index in
+                                IconView(image: userInputState.iconItems[index].value,
+                                         alpha: observedData.iconAlpha)
+                                .frame(height: iconDisplayWidth, alignment: .top)
+
+                            }
+                        }
                     }
+                    .border(observedData.appProperties.debugBorderColour, width: 2)
+                    .accessibilityHint(observedData.args.iconAccessabilityLabel.value)
                     Spacer()
                 }
                 .frame(maxWidth: appvars.windowWidth*0.8)

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -141,7 +141,13 @@ struct dialogApp: App {
         // get all the command line option values
         processCLOptionValues()
 
-        checkNotificationAuthorisation(notificationPresent: appArguments.notification.present)
+        if !(appArguments.setAppIcon.present ||
+            appArguments.getVersion.present ||
+            appArguments.buyCoffee.present ||
+            appArguments.helpOption.present ||
+            appArguments.licence.present) {
+            checkNotificationAuthorisation(notificationPresent: appArguments.notification.present)
+        }
 
         captureQuitKey(keyValue: appArguments.quitKey.value)
 


### PR DESCRIPTION
hotfix release to address some issues in 2.5.3

 - notifications causing boilerplate windows popping up
 - boilerplate text being used when "" is provided to denote a null value
 - overlay icons not showing when using a single --icon and --centreicon is used