### PR TITLE
swiftDialog 2.5.5

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -914,7 +914,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.5.4;
+				MARKETING_VERSION = 2.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -943,7 +943,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.5.4;
+				MARKETING_VERSION = 2.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/MarkdownUI",
       "state" : {
-        "revision" : "9a8119b37e09a770367eeb26e05267c75d854053",
-        "version" : "2.3.1"
+        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
+        "version" : "2.3.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
       "state" : {
-        "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
-        "version" : "5.0.2"
+        "revision" : "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
+        "version" : "5.0.1"
       }
     },
     {

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -149,7 +149,7 @@ struct AppVariables {
     var imageArray                      = [MainImage]()
     var imageCaptionArray               = [String]()
 
-    var quitAfterProcessingNotifications = true
+    var isProcessingNotification = false
 
     var quitKeyCharacter                = String("q")
 

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AppDefaults {
-    let cliversion                      = "2.5.4"
+    let cliversion                      = "2.5.5"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)
@@ -149,7 +149,8 @@ struct AppVariables {
     var imageArray                      = [MainImage]()
     var imageCaptionArray               = [String]()
 
-    var isProcessingNotification = false
+    var isProcessingNotification        = false
+    var noargs                          = false
 
     var quitKeyCharacter                = String("q")
 

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -169,7 +169,7 @@ extension CommandlineArgument {
                 self.value = numberValue.stringValue
             } else {
                 var stringValue = json[self.long].string ?? CLOptionText(optionName: self)
-                if stringValue == "" {
+                if stringValue == "" && self.defaultValue as! String == "" {
                     stringValue = "none"
                 }
                 self.value = stringValue

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -32,6 +32,7 @@ struct CommandLineArguments {
     var messageVerticalAlignment = CommandlineArgument(long: "messageposition")
     var helpMessage              = CommandlineArgument(long: "helpmessage")
     var helpImage                = CommandlineArgument(long: "helpimage")
+    var helpSheetButton          = CommandlineArgument(long: "helpsheetbuttontext", defaultValue: "button-ok".localized)
     var iconOption               = CommandlineArgument(long: "icon", short: "i", defaultValue: "default")
     var iconSize                 = CommandlineArgument(long: "iconsize", defaultValue: appvars.iconWidth)
     var iconAlpha                = CommandlineArgument(long: "iconalpha", defaultValue: "1.0")
@@ -214,6 +215,7 @@ extension CommandLineArguments {
                     case "messageVerticalAlignment": self.messageVerticalAlignment = argument
                     case "helpMessage": self.helpMessage = argument
                     case "helpImage": self.helpImage = argument
+                    case "helpSheetButton": self.helpSheetButton = argument
                     case "iconOption": self.iconOption = argument
                     case "iconSize": self.iconSize = argument
                     case "iconAlpha": self.iconAlpha = argument

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -18,13 +18,14 @@ struct CommandlineArgument {
     var helpUsage: String = "<text>"
     var present: Bool = false
     var isbool: Bool = false
+    var overrideDefaultIfNill = false
 }
 
 struct CommandLineArguments {
     // command line options that take string parameters
-    var titleOption              = CommandlineArgument(long: "title", short: "t", defaultValue: appDefaults.titleDefault)
+    var titleOption              = CommandlineArgument(long: "title", short: "t", defaultValue: appDefaults.titleDefault, overrideDefaultIfNill: true)
     var subTitleOption           = CommandlineArgument(long: "subtitle")
-    var messageOption            = CommandlineArgument(long: "message", short: "m", defaultValue: appDefaults.messageDefault)
+    var messageOption            = CommandlineArgument(long: "message", short: "m", defaultValue: appDefaults.messageDefault, overrideDefaultIfNill: true)
     var dialogStyle              = CommandlineArgument(long: "style")
     var messageAlignment         = CommandlineArgument(long: "messagealignment", defaultValue: appDefaults.messageAlignmentTextRepresentation)
     var helpAlignment            = CommandlineArgument(long: "helpalignment", defaultValue: appDefaults.messageAlignmentTextRepresentation)
@@ -33,7 +34,7 @@ struct CommandLineArguments {
     var helpMessage              = CommandlineArgument(long: "helpmessage")
     var helpImage                = CommandlineArgument(long: "helpimage")
     var helpSheetButton          = CommandlineArgument(long: "helpsheetbuttontext", defaultValue: "button-ok".localized)
-    var iconOption               = CommandlineArgument(long: "icon", short: "i", defaultValue: "default")
+    var iconOption               = CommandlineArgument(long: "icon", short: "i", defaultValue: "default", overrideDefaultIfNill: true)
     var iconSize                 = CommandlineArgument(long: "iconsize", defaultValue: appvars.iconWidth)
     var iconAlpha                = CommandlineArgument(long: "iconalpha", defaultValue: "1.0")
     var iconAccessabilityLabel   = CommandlineArgument(long: "iconalttext", defaultValue: "Dialog Icon")
@@ -42,7 +43,7 @@ struct CommandLineArguments {
     var bannerTitle              = CommandlineArgument(long: "bannertitle", defaultValue: appDefaults.titleDefault)
     var bannerText               = CommandlineArgument(long: "bannertext", defaultValue: appDefaults.titleDefault)
     var bannerHeight             = CommandlineArgument(long: "bannerheight")
-    var button1TextOption        = CommandlineArgument(long: "button1text", defaultValue: appDefaults.button1Default)
+    var button1TextOption        = CommandlineArgument(long: "button1text", defaultValue: appDefaults.button1Default, overrideDefaultIfNill: true)
     var button1ActionOption      = CommandlineArgument(long: "button1action")
     var button1ShellActionOption = CommandlineArgument(long: "button1shellaction",short: "")
     var button2TextOption        = CommandlineArgument(long: "button2text", defaultValue: appDefaults.button2Default)
@@ -60,7 +61,7 @@ struct CommandLineArguments {
     var textFieldLiveValidation  = CommandlineArgument(long: "textfieldlivevalidation", isbool: true)
     var checkbox                 = CommandlineArgument(long: "checkbox")
     var checkboxStyle            = CommandlineArgument(long: "checkboxstyle")
-    var timerBar                 = CommandlineArgument(long: "timer", defaultValue: appDefaults.timerDefaultSeconds.stringValue)
+    var timerBar                 = CommandlineArgument(long: "timer", defaultValue: appDefaults.timerDefaultSeconds)
     var progressBar              = CommandlineArgument(long: "progress")
     var progressText             = CommandlineArgument(long: "progresstext", defaultValue: " ")
     var mainImage                = CommandlineArgument(long: "image", short: "g")
@@ -170,7 +171,7 @@ extension CommandlineArgument {
                 self.value = numberValue.stringValue
             } else {
                 var stringValue = json[self.long].string ?? CLOptionText(optionName: self)
-                if stringValue == "" && self.defaultValue as! String == "" {
+                if stringValue == "" && self.overrideDefaultIfNill {
                     stringValue = "none"
                 }
                 self.value = stringValue

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -84,7 +84,9 @@ func processCLOptionValues() {
     // if argument count is < 2 print help and exit
     if CommandLine.arguments.count < 2 {
         SDHelp(arguments: appArguments).printHelpShort()
-        quitDialog(exitCode: 0)
+        //if !appvars.quitAfterProcessingNotifications {
+        //    quitDialog(exitCode: 0)
+        //}
     }
     writeLog("Argument count: \(CommandLine.arguments.count)", logLevel: .debug)
     for argument in CommandLine.arguments {

--- a/dialog/Functions/Log.swift
+++ b/dialog/Functions/Log.swift
@@ -17,6 +17,54 @@ func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = osLog
         // print debug and error to sterr
         print("\(logLevel.stringValue.uppercased()): \(message)", to: &standardError)
     }
+    // also write to a log file
+    // writeFileLog(message: message, logLevel: logLevel)
+}
+
+func writeFileLog(message: String, logLevel: OSLogType) {
+    // write to a log file for accessability of those that don't want to manage the system log
+    let logFilePath = "/private/var/log/dialog.log"
+    if logLevel == .debug && !appvars.debugMode {
+        return
+    }
+    let logFileURL = URL(fileURLWithPath: logFilePath)
+    if !checkFileExists(path: logFilePath) {
+        FileManager.default.createFile(atPath: logFileURL.path, contents: nil, attributes: nil)
+        let attributes = [FileAttributeKey.posixPermissions: 0o666]
+        do {
+            try FileManager.default.setAttributes(attributes, ofItemAtPath: logFileURL.path)
+        } catch {
+            printStdErr("\(OSLogType.error.stringValue.uppercased()): Unable to create log file at \(logFilePath)")
+            printStdErr(error.localizedDescription)
+            return
+        }
+    }
+    do {
+        let fileHandle = try FileHandle(forWritingTo: logFileURL)
+        defer { fileHandle.closeFile() }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        let date = dateFormatter.string(from: Date())
+        let logEntry = "\(date) \(logLevel.stringValue): \(message)\n"
+
+        fileHandle.seekToEndOfFile()
+        fileHandle.write(logEntry.data(using: .utf8)!)
+    } catch {
+        printStdErr("\(OSLogType.error.stringValue.uppercased()): Unable to read log file at \(logFilePath)")
+        printStdErr(error.localizedDescription)
+        return
+    }
+}
+
+func printStdErr(_ errorMessage: String) {
+    var standardError = StandardError()
+    print(errorMessage, to: &standardError)
+}
+
+func checkFileExists(path: String) -> Bool {
+    return FileManager.default.fileExists(atPath: path)
 }
 
 extension OSLogType {

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -319,3 +319,13 @@ func captureQuitKey(keyValue: String) {
         return event
     }
 }
+
+class BackgroundTimer {
+    private let queue = DispatchQueue(label: "background.timer.queue")
+
+    func startTimer(duration: TimeInterval, completion: @escaping () -> Void) {
+        queue.asyncAfter(deadline: .now() + duration) {
+            completion()
+        }
+    }
+}

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4800</string>
+	<string>4802</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4792</string>
+	<string>4800</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -68,8 +68,14 @@ if [ $(id -u) -eq 0 ]; then
             exit 1
         fi
         # make sure the console user has read access to the command file
-        # -h flag is used to dereference the symlink if it is one, which it shouldn't be but just in case, to be sure, you never know, etc.
-        /bin/chmod -h 666 "$commandfile"
+        if ! sudo -u currentUser test -r "$commandfile"; then
+            echoerr ""
+            echoerr "ERROR: command file ${commandfile} is not readable by user $currentUser"
+            echoerr "Check permissions are correct. The dialog process will not be able to read updates"
+            echoerr "aborting"
+            echoerr ""
+            exit 1
+        fi
     fi
     runAsUser "$dialogbin" "$@"
 else

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -35,24 +35,22 @@ if [ ! -e "$dialogbin" ]; then
     exit 255
 fi
 
-# check to see if the command file exists
-if [[ ! -e "$commandfile" ]]; then
-    /usr/bin/touch "$commandfile"
-# check to see if the command file is writeable
-elif [[ ! -r "$commandfile" ]]; then
-    echoerr ""
-    echoerr "Warning: command file ${commandfile} is not readable by user $currentUser"
-    echoerr ""
-fi
-
 # If we're running as root, launch swiftDialog as the user.
 if [ $(id -u) -eq 0 ]; then
     if [ -e $commandfile ]; then
-        # make sure the console user has read access to the command file
-        /bin/chmod 666 "$commandfile"
+        # Remove the command file if it exists
+        # Addresses issues with local privilege escalation via insecure file system operations
+        # (the dialog app will create this file if it doesn't exist)
+        rm $commandfile
     fi
-
     runAsUser "$dialogbin" "$@"
 else
+    # check to see if the command file exists is readable by the user
+    if [[ -e "$commandfile" ]] && [[ ! -r "$commandfile" ]]; then
+        echoerr ""
+        echoerr "Warning: command file ${commandfile} is not readable by user $currentUser"
+        echoerr ""
+        exit 255
+    fi
     "$dialogbin" "$@"
 fi

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -68,7 +68,7 @@ if [ $(id -u) -eq 0 ]; then
             exit 1
         fi
         # make sure the console user has read access to the command file
-        if ! sudo -u currentUser test -r "$commandfile"; then
+        if ! sudo -u $currentUser test -r "$commandfile"; then
             echoerr ""
             echoerr "ERROR: command file ${commandfile} is not readable by user $currentUser"
             echoerr "Check permissions are correct. The dialog process will not be able to read updates"

--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -4,11 +4,13 @@ uid=$(id -u "$currentUser")
 dialogpath="/Library/Application Support/Dialog/Dialog.app"
 dialogbin="$dialogpath/Contents/MacOS/Dialog"
 commandfile=$(echo "$@" | awk -v pattern="--commandfile" '{for (i=0;i<=NF;i++) {if ($i==pattern) print $(i+1) }}')
-
+commandFileInUse=0
 echoerr() { echo "$@" 1>&2; }
 
-if [[ -z $commandfile ]]; then
+if [ -z $commandfile ]; then
     commandfile="/var/tmp/dialog.log"
+else
+    commandFileInUse=1
 fi
 
 # convenience function to run a command as the current user
@@ -29,28 +31,48 @@ runAsUser() {
   fi
 }
 
+# Check to see if the command file is a symbolic link and abort if it is
+if [ -L $commandfile ]; then
+    echo "WARNING: ${commandfile} is a symbolic link - aborting"
+    echo "Did someone try and symlink the command file to a different location?"
+    echo "${commandfile} is a symbolic link to $(readlink $commandfile)"
+    echo "If you want to use a different command file, specify it with the --commandfile option"
+    exit 1
+fi
+
 # Check to make sure we have a binary to run
 if [ ! -e "$dialogbin" ]; then
     echoerr "ERROR: Cannot find swiftDialog binary at $dialogbin"
     exit 255
 fi
 
+# check to see if the command file exists and create it if it doesn't
+if [ ! -e "$commandfile" ]; then
+    /usr/bin/touch "$commandfile"
+# check to see if the command file is writeable
+elif [ ! -r "$commandfile" ]; then
+    echoerr ""
+    echoerr "Warning: command file ${commandfile} is not readable by user $currentUser"
+    echoerr ""
+fi
+
 # If we're running as root, launch swiftDialog as the user.
 if [ $(id -u) -eq 0 ]; then
-    if [ -e $commandfile ]; then
-        # Remove the command file if it exists
-        # Addresses issues with local privilege escalation via insecure file system operations
-        # (the dialog app will create this file if it doesn't exist)
-        rm $commandfile
+    # check if the command file is a file and in use
+    if [ -f $commandfile ] && [ $commandFileInUse -eq 1 ]; then
+        # make sure the console user has read access to the command file
+        # we need to do this safely though in case something has replaced the command file with a symlink
+        if [ -L $commandfile ]; then
+            # this should be caught earlier in the script, but just in case
+            echoerr "ERROR: ${commandfile} is a symbolic link - aborting"
+            exit 1
+        fi
+        # make sure the console user has read access to the command file
+        # -h flag is used to dereference the symlink if it is one, which it shouldn't be but just in case, to be sure, you never know, etc.
+        /bin/chmod -h 666 "$commandfile"
     fi
     runAsUser "$dialogbin" "$@"
 else
-    # check to see if the command file exists is readable by the user
-    if [[ -e "$commandfile" ]] && [[ ! -r "$commandfile" ]]; then
-        echoerr ""
-        echoerr "Warning: command file ${commandfile} is not readable by user $currentUser"
-        echoerr ""
-        exit 255
-    fi
     "$dialogbin" "$@"
 fi
+

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -541,6 +541,9 @@ class FileReader {
                 default:
                     observedData.args.blurScreen.present = false
                     blurredScreen.hide()
+                    if !observedData.args.forceOnTop.present {
+                        NSApp.windows.first?.level = .normal
+                    }
                     NSApp.activate(ignoringOtherApps: true)
                 }
 

--- a/dialog/Views/ButtonView.swift
+++ b/dialog/Views/ButtonView.swift
@@ -16,6 +16,7 @@ struct ButtonView: View {
 
     var button1action: String = ""
     var buttonShellAction: Bool = false
+    var buttonCentreStyle: Bool = false
 
     var defaultExit: Int32 = 0
     var cancelExit: Int32 = 2
@@ -25,6 +26,8 @@ struct ButtonView: View {
 
     init(observedDialogContent: DialogUpdatableContent) {
         self.observedData = observedDialogContent
+
+        buttonCentreStyle = ["centre","center","centred","centered"].contains(observedDialogContent.args.buttonStyle.value)
 
         if observedDialogContent.args.timerBar.present {
             progressSteps = observedDialogContent.args.timerBar.value.floatValue()
@@ -41,7 +44,7 @@ struct ButtonView: View {
     }
 
     var body: some View {
-        if ["centre","center","centred","centered"].contains(observedData.args.buttonStyle.value) {
+        if buttonCentreStyle {
             HStack {
                 Spacer()
                     .frame(width: 20)
@@ -67,7 +70,7 @@ struct ButtonView: View {
                     }
                     )
                     .keyboardShortcut(observedData.appProperties.button1DefaultAction)
-                    .disabled(observedData.args.button1Disabled.present)
+                    .disabled(buttonCentreStyle ? false : observedData.args.button1Disabled.present)
                 }
                 Spacer()
                     .frame(width: 20)
@@ -85,7 +88,7 @@ struct ButtonView: View {
                     }
                     )
                     .keyboardShortcut(observedData.appProperties.button1DefaultAction)
-                    .disabled(observedData.args.button1Disabled.present)
+                    .disabled(buttonCentreStyle ? false : observedData.args.button1Disabled.present)
                 }
 
                 if observedData.args.button2Option.present || observedData.args.button2TextOption.present {

--- a/dialog/Views/HelpView.swift
+++ b/dialog/Views/HelpView.swift
@@ -50,7 +50,7 @@ struct HelpView: View {
             Button(action: {
                 observedData.appProperties.showHelpMessage = false
             }, label: {
-                Text("button-ok".localized)
+                Text(observedData.args.helpSheetButton.value)
             })
             .padding(appDefaults.sidePadding)
             .keyboardShortcut(.defaultAction)

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -125,6 +125,8 @@ struct dialogApp: App {
 
         if CommandLine.arguments.count > 1 {
             appvars.isProcessingNotification = false
+        } else {
+            appvars.noargs = true
         }
 
         writeLog("Dialog Launched", logLevel: .info)
@@ -201,16 +203,24 @@ struct dialogApp: App {
             appArguments.movableWindow.present = true
         }
 
-        // bring to front on launch
-        writeLog("Activating", logLevel: .debug)
-        NSApp.activate(ignoringOtherApps: true)
-        writeLog("Activated", logLevel: .debug)
+        if appvars.noargs {
+            let timer = BackgroundTimer()
+            timer.startTimer(duration: 3.0) {
+                writeLog("No arguments. Quitting", logLevel: .debug)
+                quitDialog(exitCode: 0)
+            }
+        } else {
+            // bring to front on launch
+            writeLog("Activating", logLevel: .debug)
+            NSApp.activate(ignoringOtherApps: true)
+            writeLog("Activated", logLevel: .debug)
+        }
     }
 
     var body: some Scene {
 
         WindowGroup {
-            if !appArguments.notification.present {
+            if !appArguments.notification.present && !appvars.noargs {
                 ZStack {
                     if appArguments.miniMode.present {
                         MiniView(observedDialogContent: observedData)

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -24,6 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         writeLog("reading notification", logLevel: .debug)
 
         if response.notification.request.content.categoryIdentifier == "SD_NOTIFICATION" {
+            appvars.isProcessingNotification = true
             processNotification(response: response)
         } else {
             writeLog("unknown notification type", logLevel: .debug)
@@ -32,7 +33,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // call the completion handler when done.
         completionHandler()
         // quit dialog since we dont need to show anything
-        if appvars.quitAfterProcessingNotifications {
+        if appvars.isProcessingNotification {
             quitDialog(exitCode: appDefaults.exitNow.code)
         }
     }
@@ -123,7 +124,7 @@ struct dialogApp: App {
         appvars.debugMode = CLOptionPresent(optionName: appArguments.debug)
 
         if CommandLine.arguments.count > 1 {
-            appvars.quitAfterProcessingNotifications = false
+            appvars.isProcessingNotification = false
         }
 
         writeLog("Dialog Launched", logLevel: .info)


### PR DESCRIPTION
Fixes:

 - #476 Notifications no longer trigger action items from --button1action or --button2action
 - #473 Applying the blur effect then turning it off puts a dialog on top even if it is not on top
 - #477 timer flag causing dialog to stay open indefinitely
 - Added processing to handle if no arguments are used on the command line. This should allow enough time for whatever script is being launced from a notification to launch.
 - Fix issue where default string values were not being populated on arguments with optional values
 - updated logic for `/usr/local/bin/dialog` to avoid permission issues and warn if the command file is detected as a symlink

Updates:
 - #463 customize the label on the Help pane’s close button to any desired text `--helpsheetbuttontext`