### PR TITLE
Additional options for working with notifications

### DIFF
--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -93,6 +93,7 @@ struct CommandLineArguments {
     var preferredViewOrder       = CommandlineArgument(long: "vieworder")
     var preferredAppearance      = CommandlineArgument(long: "appearance")
     var setAppIcon               = CommandlineArgument(long: "seticon")
+    var notificationIdentifier   = CommandlineArgument(long: "identifier", short: "id")
 
     // command line options that take no additional parameters
     var button1Disabled          = CommandlineArgument(long: "button1disabled", isbool: true)
@@ -138,6 +139,7 @@ struct CommandLineArguments {
     var loginWindow              = CommandlineArgument(long: "loginwindow", isbool: true)
     var hideDefaultKeyboardAction = CommandlineArgument(long: "hidedefaultkeyboardaction", isbool: true)
     var alwaysReturnUserInput      = CommandlineArgument(long: "alwaysreturninput", isbool: true)
+    var removeNotification        = CommandlineArgument(long: "remove", isbool: true)
 }
 
 extension CommandlineArgument {
@@ -318,6 +320,8 @@ extension CommandLineArguments {
                     case "hideDefaultKeyboardAction": self.hideDefaultKeyboardAction = argument
                     case "alwaysReturnUserInput": self.alwaysReturnUserInput = argument
                     case "setAppIcon": self.setAppIcon = argument
+                    case "removeNotification": self.removeNotification = argument
+                    case "notificationIdentifier": self.notificationIdentifier = argument
                     default: break
                     }
                 }

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -147,9 +147,27 @@ struct SDHelp {
           --\(appArguments.subTitleOption.long) <text>
           --\(appArguments.messageOption.long) <text> (as plain text. newlines supported as \\n)
           --\(appArguments.iconOption.long) <image> *
+          --\(appArguments.notificationIdentifier.long) <text>
+          --\(appArguments.removeNotification.long)
 
         * <image> must refer to a local file or app bundle. Remote images sources are not supported.
 """
+        
+        argument.notificationIdentifier.helpShort = "Set the notification identifier"
+        argument.notificationIdentifier.helpLong = """
+        Identifier is used to uniquely identify the notification.
+        If not specified, a random identifier will be generated.
+        
+        Use this identifier to remove the notification with the --\(appArguments.removeNotification.long) option
+        
+        If the identifier is not unique, the previous notification will be replaced by the new one.
+        """
+        
+        argument.removeNotification.helpShort = "Remove a system notification"
+        argument.removeNotification.helpLong = """
+        Removes the notification with the specified identifier.
+        If no identifier is specified, all notifications will be removed.
+        """
 
         argument.dialogStyle.helpShort = "Configure a pre-set window style"
         argument.dialogStyle.helpUsage = "presentation | mini | centered | alert | caution | warning"

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -31,39 +31,63 @@ func checkNotificationAuthorisation(notificationPresent: Bool) {
 func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
     // check if we are sending a notification
     if arguments.notification.present {
-        writeLog("Sending a notification")
-
-        var notificationIcon = ""
-        if appArguments.iconOption.present {
-            notificationIcon = appArguments.iconOption.value
+        if arguments.removeNotification.present {
+            writeLog("Removing notifications")
+            removeNotification(identifier: arguments.notificationIdentifier.value)
         }
-
-        var acceptActionLabel: String = ""
-        var declineActionLabel: String = ""
-        if arguments.button1TextOption.present {
-            acceptActionLabel = arguments.button1TextOption.value
+        else {
+            writeLog("Sending a notification")
+            
+            var notificationIcon = ""
+            if appArguments.iconOption.present {
+                notificationIcon = appArguments.iconOption.value
+            }
+            
+            var acceptActionLabel: String = ""
+            var declineActionLabel: String = ""
+            if arguments.button1TextOption.present {
+                acceptActionLabel = arguments.button1TextOption.value
+            }
+            if arguments.button2TextOption.present {
+                declineActionLabel = arguments.button2TextOption.value
+            }
+            sendNotification(title: arguments.titleOption.value,
+                             subtitle: arguments.subTitleOption.value,
+                             message: arguments.messageOption.value,
+                             image: notificationIcon,
+                             identifier: arguments.notificationIdentifier.value,
+                             acceptString: acceptActionLabel,
+                             acceptAction: arguments.button1ActionOption.value,
+                             declineString: declineActionLabel,
+                             declineAction: arguments.button2ActionOption.value,
+                             notificationSoundEnabled: arguments.notificationGoPing.present)
+            usleep(100000)
         }
-        if arguments.button2TextOption.present {
-            declineActionLabel = arguments.button2TextOption.value
-        }
-        sendNotification(title: arguments.titleOption.value,
-                         subtitle: arguments.subTitleOption.value,
-                         message: arguments.messageOption.value,
-                         image: notificationIcon,
-                         acceptString: acceptActionLabel,
-                         acceptAction: arguments.button1ActionOption.value,
-                         declineString: declineActionLabel,
-                         declineAction: arguments.button2ActionOption.value,
-                         notificationSoundEnabled: arguments.notificationGoPing.present)
-        usleep(100000)
     }
     return arguments.notification.present
+}
+
+func removeNotification(identifier: String? = nil) {
+    let notificationCenter = UNUserNotificationCenter.current()
+    
+    if let id = identifier, !id.isEmpty {
+        // Clear a specific notification using its identifier
+        notificationCenter.removeDeliveredNotifications(withIdentifiers: [id])
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [id])
+        writeLog("Removed notification with identifier: \(id)", logLevel: .info)
+    } else {
+        // Clear all notifications
+        notificationCenter.removeAllDeliveredNotifications()
+        notificationCenter.removeAllPendingNotificationRequests()
+        writeLog("Removed all notifications", logLevel: .info)
+    }
 }
 
 func sendNotification(title: String = "",
                       subtitle: String = "",
                       message: String = "",
                       image: String = "",
+                      identifier: String = "",
                       acceptString: String = "Open",
                       acceptAction: String = "",
                       declineString: String = "Close",
@@ -144,9 +168,9 @@ func sendNotification(title: String = "",
                 }
 
                 // Create the request
-                //let uuidString = UUID().uuidString
-                let request = UNNotificationRequest(identifier: UUID().uuidString,
-                            content: content, trigger: nil)
+                // Use provided identifier or generated UUID
+                let request = UNNotificationRequest(identifier: identifier.isEmpty ? UUID().uuidString : identifier,
+                                                    content: content, trigger: nil)
 
                 // Schedule the request with the system.
                 notification.add(request) { (error) in


### PR DESCRIPTION
Ability to set an identifier for a notification, allowing you to easily replace a notification with an updated one. Also the ability to remove a specific notification by identifier or all notifications.

Example:

```
dialog --notification --identifier "update.message" --title "Updates" --message "Please update by tonight."
dialog --notification --identifier "update.message" --title "Updates" --message "Please update within the next hour."
dialog --notification --identifier "update.message" --remove
```

https://github.com/user-attachments/assets/725cd1f4-ef3c-4fad-9bfc-e371d7720835

