### PR TITLE
Added buttonsize as a command line and control file variable.

### DIFF
--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -27,7 +27,13 @@ struct AppDefaults {
     let button2Default                  = String("button-cancel".localized)
     let buttonInfoDefault               = String("button-more-info".localized)
     let buttonInfoActionDefault         = String("")
-
+    let buttonSizeStates : [String : ControlSize] = ["mini": .mini,
+                                                      "small": .small,
+                                                      "regular": .regular,
+                                                      "large": .large]
+    let buttonSize                      = String("regular")
+    
+    
     // Content padding
     let sidePadding                     = CGFloat(15)
     let topPadding                      = CGFloat(10)
@@ -115,6 +121,7 @@ struct AppVariables {
     var iconHeight                     = CGFloat(260)      // set default image area height
     var titleHeight                     = CGFloat(50)
     var bannerHeight                    = CGFloat(-10)
+    var buttonSize                      = ControlSize.regular
 
     var scaleFactor                     = CGFloat(1)
 

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -51,6 +51,7 @@ struct CommandLineArguments {
     var buttonInfoTextOption     = CommandlineArgument(long: "infobuttontext", defaultValue: appDefaults.buttonInfoDefault)
     var buttonInfoActionOption   = CommandlineArgument(long: "infobuttonaction")
     var buttonStyle              = CommandlineArgument(long: "buttonstyle")
+    var buttonSize               = CommandlineArgument(long: "buttonsize", defaultValue: "regular")
     var dropdownTitle            = CommandlineArgument(long: "selecttitle")
     var dropdownValues           = CommandlineArgument(long: "selectvalues")
     var dropdownDefault          = CommandlineArgument(long: "selectdefault")
@@ -234,6 +235,7 @@ extension CommandLineArguments {
                     case "buttonInfoTextOption": self.buttonInfoTextOption = argument
                     case "buttonInfoActionOption": self.buttonInfoActionOption = argument
                     case "buttonStyle": self.buttonStyle = argument
+                    case "buttonSize": self.buttonSize = argument
                     case "dropdownTitle": self.dropdownTitle = argument
                     case "dropdownValues": self.dropdownValues = argument
                     case "dropdownDefault": self.dropdownDefault = argument

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -178,6 +178,12 @@ struct SDHelp {
         When using this mode, --\(argument.timerBar.long) and --\(argument.infoButtonOption.long) are not available
         In "stack" mode, Info button is not available.
 """
+        argument.buttonSize.helpShort = "Configure how large the buttons are"
+        argument.buttonSize.helpUsage = "mini|small|regular|large"
+        argument.buttonSize.helpLong = """
+        Adjusts the size of the buttons at the bottom of the window.
+        Default: regular
+"""
 
         argument.webcontent.helpShort = "Display a web page"
         argument.webcontent.helpUsage = "<url>"

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -275,6 +275,10 @@ func processCLOptions(json: JSON = getJSON()) {
         default: ()
         }
     }
+    
+    if appArguments.buttonSize.present {
+        appvars.buttonSize = appDefaults.buttonSizeStates[appArguments.buttonSize.value] ?? .regular
+    }
 
     if appArguments.dropdownValues.present {
         writeLog("\(appArguments.dropdownValues.long) present")

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -361,7 +361,17 @@ class FileReader {
                 default:
                     observedData.args.button2Disabled.present = false
                 }
+                
+            // Button control size
+            case "buttonsize:":
+                switch argument {
+                case "mini", "small", "regular", "large":
+                    observedData.appProperties.buttonSize = appDefaults.buttonSizeStates[argument] ?? .regular
+                default:
+                    observedData.appProperties.buttonSize = .regular
+                }
 
+                
             // Info Button label
             case "\(observedData.args.infoButtonOption.long):":
                 observedData.args.infoButtonOption.value = argument
@@ -601,7 +611,8 @@ class DialogUpdatableContent: ObservableObject {
     @Published var sheetErrorMessage: String
 
     @Published var updateView: Bool = true
-
+    @Published var constructionKitShown: Bool = false
+    
     var status: StatusState
 
     let commandFilePermissions: [FileAttributeKey: Any] = [FileAttributeKey.posixPermissions: 0o666]

--- a/dialog/Views/ButtonView.swift
+++ b/dialog/Views/ButtonView.swift
@@ -74,7 +74,7 @@ struct ButtonView: View {
                 }
                 Spacer()
                     .frame(width: 20)
-            }
+            }.controlSize(observedData.appProperties.buttonSize)
         } else if ["stack"].contains(observedData.args.buttonStyle.value) {
             VStack {
                 if !(observedData.args.button1TextOption.value == "none") {
@@ -106,7 +106,7 @@ struct ButtonView: View {
                     TimerView(progressSteps: progressSteps, visible: !observedData.args.hideTimerBar.present, observedDialogContent: observedData, stacked: true)
                         .frame(alignment: .bottom )
                 }
-            }
+            }.controlSize(observedData.appProperties.buttonSize)
         } else {
             // Buttons
             HStack {
@@ -169,6 +169,7 @@ struct ButtonView: View {
                     HelpButton(observedDialogContent: observedData)
                 }
             }
+            .controlSize(observedData.appProperties.buttonSize)
         }
     }
 }

--- a/dialog/Views/ConstructionKit/CKButtonView.swift
+++ b/dialog/Views/ConstructionKit/CKButtonView.swift
@@ -18,6 +18,32 @@ struct CKButtonView: View {
     var body: some View {
         VStack { //buttons
             VStack {
+                     LabelView(label: "ck-buttonsize".localized)
+                     HStack {
+                         Button("mini") {
+                             observedData.args.buttonSize.value = "mini"
+                         } .controlSize(.mini)
+                         
+                         Button("small") {
+                             observedData.args.buttonSize.value = "small"
+                         } .controlSize(.small)
+                         Button("regular") {
+                             observedData.args.buttonSize.value = "regular"
+                         } .controlSize(.regular)
+                         Button("large") {
+                             observedData.args.buttonSize.value = "large"
+                         } .controlSize(.large)
+                         
+                         
+                         TextField("", text: $observedData.args.buttonSize.value)
+                             .onChange(of: observedData.args.buttonSize.value)
+                                { newValue in
+                                    observedData.appProperties.buttonSize = appDefaults.buttonSizeStates[newValue] ?? .regular
+                                }
+               
+                     }
+                 }
+            VStack {
                 LabelView(label: "ck-button1".localized)
                 HStack {
                     Toggle("ck-disabled".localized, isOn: $observedData.args.button1Disabled.present)

--- a/dialog/Views/ConstructionKit/ConstructionKitView.swift
+++ b/dialog/Views/ConstructionKit/ConstructionKitView.swift
@@ -95,6 +95,10 @@ struct JSONView: View {
         if observedDialogContent.appProperties.titleFontColour != .primary {
             json[appArguments.titleFont.long].dictionaryObject = ["colour": observedDialogContent.appProperties.titleFontColour.hexValue]
         }
+        
+        if observedDialogContent.appProperties.buttonSize != .regular {
+            json[appArguments.buttonSize.long].string = observedDialogContent.args.buttonSize.value
+        }
 
         // convert the JSON to a raw String
         jsonFormattedOutout = json.rawString() ?? "json is nil"

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -198,11 +198,7 @@ struct dialogApp: App {
             FullscreenView(observedData: observedData).showFullScreen()
         }
 
-        if appArguments.constructionKit.present {
-            ConstructionKitView(observedDialogContent: observedData).showConstructionKit()
-            appArguments.movableWindow.present = true
-        }
-
+        
         if appvars.noargs {
             let timer = BackgroundTimer()
             timer.startTimer(duration: 3.0) {
@@ -237,6 +233,16 @@ struct dialogApp: App {
                         }
                     }
                     DebugOverlay(observedData: observedData)
+                }
+                .onAppear {
+                    // Only show the construction kit once, if needed.
+                    if appArguments.constructionKit.present && !observedData.constructionKitShown {
+                        observedData.constructionKitShown = true
+                        DispatchQueue.main.async {
+                            ConstructionKitView(observedDialogContent: observedData).showConstructionKit()
+                            appArguments.movableWindow.present = true
+                        }
+                    }
                 }
                 .preferredColorScheme(observedData.args.preferredAppearance.present &&
                                       observedData.args.preferredAppearance.value.lowercased() == "dark" ? .dark

--- a/dialog/extras/Localisations/en-AU.lproj/Localizable.strings
+++ b/dialog/extras/Localisations/en-AU.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 "ck-sidebar"            = "Sidebar";
 "ck-dataentry"          = "Data Entry";
 "ck-buttons"            = "Buttons";
+"ck-buttonsize"         = "Button Size";
 "ck-advanced"           = "Advanced";
 "ck-listitems"          = "List Items";
 "ck-images"             = "Images";

--- a/dialog/extras/Localisations/en.lproj/Localizable.strings
+++ b/dialog/extras/Localisations/en.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 "ck-sidebar"            = "Sidebar";
 "ck-dataentry"          = "Data Entry";
 "ck-buttons"            = "Buttons";
+"ck-buttonsize"         = "Button Size";
 "ck-advanced"           = "Advanced";
 "ck-listitems"          = "List Items";
 "ck-images"             = "Images";


### PR DESCRIPTION
Added support for mini, small and large button button sizes, using the built in macOS sizes. The button size will default to the current value of regular if not specified or not valid.

Added support for button size to the builder mode for testing and JSON generation.

Tested with control files, json input and command line, and with incorrect values.

Button style is applied to button1, button2 and the info button. It is also applied iin the normal and stacked button layout.

 It does not scale the help button, which is a fixed size.
 
<img width="728" alt="image" src="https://github.com/user-attachments/assets/b1275819-0407-44e6-aa47-33f5dc87e028" />

<img width="803" alt="image" src="https://github.com/user-attachments/assets/f2684b8b-83f2-4488-8bfe-fcf4b055a44c" />
