### PR TITLE
Added options to hide and show the dialog window from the command file

### DIFF
--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -512,6 +512,17 @@ class FileReader {
             case "activate:":
                 writeToLog("activating window")
                 NSApp.activate(ignoringOtherApps: true)
+                
+            // hide
+            case "hide:":
+                writeToLog("hiding windows")
+                NSApp.hide(self)
+                
+            // hide
+            case "show:":
+                writeToLog("Showing windows")
+                NSApp.unhide(self)
+                NSApp.activate(ignoringOtherApps: true)
 
             // icon alpha
             case "\(observedData.args.iconAlpha.long):":


### PR DESCRIPTION
Here is a use case :
I have a main window, but in certain circumstances, I need to display a secondary window (hence a second swiftDialog instance), but I need to make sure that it appears on top of the main window (that part is easy), but I also need to prevent users from clicking on the main window and bring it to the front, as this would cover my secondary window (which is smaller in size).
Right now, what I’m doing is resizing the main window so that it gets “hidden” by the secondary window, and then resizing it back when the secondary window is closed. But that’s a bit ugly. It would be great if I could hide (but not close) the main window, while the secondary window is shown.