### PR TITLE
Update dialog script version message when no user logged in

### DIFF
--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -1,6 +1,6 @@
 #!/bin/sh
 currentUser=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
-uid=$(id -u "$currentUser")
+uid=$(id -u "$currentUser" 2>/dev/null)
 dialogpath="/Library/Application Support/Dialog/Dialog.app"
 dialogbin="$dialogpath/Contents/MacOS/Dialog"
 commandfile=$(echo "$@" | awk -v pattern="--commandfile" '{for (i=0;i<=NF;i++) {if ($i==pattern) print $(i+1) }}')


### PR DESCRIPTION
Suppresses the no user error when calling the --version command using the dialog shell script if no user is logged in: /usr/local/bin/dialog --version
id: loginwindow: no such user
2.5.5.4802

Per bartreardon: a proper workaround would be to change that line to uid=$(id -u "$currentUser" 2>/dev/null) since the error is output on stderr. As such, it's relatively innocuous as is since it won't appear in the output and $uid will be void.