### PR TITLE
Use whole path for scutil

### DIFF
--- a/dialog/Package/pkgroot/usr/local/bin/dialog
+++ b/dialog/Package/pkgroot/usr/local/bin/dialog
@@ -1,5 +1,5 @@
 #!/bin/sh
-currentUser=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
+currentUser=$(echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | awk '/Name :/ { print $3 }')
 uid=$(id -u "$currentUser")
 dialogpath="/Library/Application Support/Dialog/Dialog.app"
 dialogbin="$dialogpath/Contents/MacOS/Dialog"


### PR DESCRIPTION
Use the whole path for scutil to fix issues when running from a cron script, etc.

Without the whole path I get `line 2: scutil: command not found` when calling dialog from cron.