### PR TITLE
Add inspect mode with service-oriented validation architecture

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -60,7 +60,22 @@
 		41D81E6C25F8209F00D1F7E1 /* CLOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E6B25F8209F00D1F7E1 /* CLOptions.swift */; };
 		41D81E7125F845D200D1F7E1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7025F845D200D1F7E1 /* AppState.swift */; };
 		41D81E7925F870A500D1F7E1 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7825F870A500D1F7E1 /* System.swift */; };
+		927EC2B71BCB4E698795A084 /* DebouncedUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */; };
 		94072E492AFE931300B2A5C3 /* Font+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94072E482AFE931300B2A5C3 /* Font+Additions.swift */; };
+		B4608E5B819446BC9AADDC8F /* FileSystemCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F647DDE9CB42EBA9D931B9 /* FileSystemCache.swift */; };
+		BAC04B1E2E2FB3E6006B0F89 /* Preset3Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B1B2E2FB3E6006B0F89 /* Preset3Layout.swift */; };
+		BAC04B1F2E2FB3E6006B0F89 /* Preset2Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B1A2E2FB3E6006B0F89 /* Preset2Layout.swift */; };
+		BAC04B202E2FB3E6006B0F89 /* Preset1Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B192E2FB3E6006B0F89 /* Preset1Layout.swift */; };
+		BAC04B212E2FB3E6006B0F89 /* InspectLayoutProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B162E2FB3E6006B0F89 /* InspectLayoutProtocol.swift */; };
+		BAC04B222E2FB3E6006B0F89 /* InspectState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B172E2FB3E6006B0F89 /* InspectState.swift */; };
+		BAC04B232E2FB3E6006B0F89 /* Preset4Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B1C2E2FB3E6006B0F89 /* Preset4Layout.swift */; };
+		600393D08F1240E680E37402 /* Preset5Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600393D08F1240E680E37403 /* Preset5Layout.swift */; };
+		BAC04B242E2FB3E6006B0F89 /* FSEventsInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B152E2FB3E6006B0F89 /* FSEventsInspector.swift */; };
+		BAC04B252E2FB3E6006B0F89 /* InspectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B182E2FB3E6006B0F89 /* InspectView.swift */; };
+		0E97D6F92AD54BE3B1A5467D /* InspectValidationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E97D6F92AD54BE3B1A5466D /* InspectValidationService.swift */; };
+		159C2690A9E64B5C96D813E8 /* InspectConfigurationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159C2690A9E64B5C96D813D8 /* InspectConfigurationService.swift */; };
+		BAC04B282E2FB401006B0F89 /* AppInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B262E2FB401006B0F89 /* AppInspector.swift */; };
+		BAC04B292E2FB401006B0F89 /* InspectConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B272E2FB401006B0F89 /* InspectConstants.swift */; };
 		CC21904B2A7B994A00269525 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904A2A7B994A00269525 /* Preferences.swift */; };
 		CC21904E2A7BC3E000269525 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904D2A7BC3E000269525 /* Strings.swift */; };
 		CC2190502A7BC9FE00269525 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904F2A7BC9FE00269525 /* Log.swift */; };
@@ -166,6 +181,20 @@
 		41FD45FD26C40366006976FC /* TimerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		41FD45FF26C8DC5D006976FC /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		94072E482AFE931300B2A5C3 /* Font+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Additions.swift"; sourceTree = "<group>"; };
+		A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncedUpdater.swift; sourceTree = "<group>"; };
+		BAC04B152E2FB3E6006B0F89 /* FSEventsInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FSEventsInspector.swift; sourceTree = "<group>"; };
+		BAC04B162E2FB3E6006B0F89 /* InspectLayoutProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectLayoutProtocol.swift; sourceTree = "<group>"; };
+		BAC04B172E2FB3E6006B0F89 /* InspectState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectState.swift; sourceTree = "<group>"; };
+		BAC04B182E2FB3E6006B0F89 /* InspectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectView.swift; sourceTree = "<group>"; };
+		0E97D6F92AD54BE3B1A5466D /* InspectValidationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectValidationService.swift; sourceTree = "<group>"; };
+		159C2690A9E64B5C96D813D8 /* InspectConfigurationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectConfigurationService.swift; sourceTree = "<group>"; };
+		BAC04B192E2FB3E6006B0F89 /* Preset1Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset1Layout.swift; sourceTree = "<group>"; };
+		BAC04B1A2E2FB3E6006B0F89 /* Preset2Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset2Layout.swift; sourceTree = "<group>"; };
+		BAC04B1B2E2FB3E6006B0F89 /* Preset3Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset3Layout.swift; sourceTree = "<group>"; };
+		BAC04B1C2E2FB3E6006B0F89 /* Preset4Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset4Layout.swift; sourceTree = "<group>"; };
+		600393D08F1240E680E37403 /* Preset5Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset5Layout.swift; sourceTree = "<group>"; };
+		BAC04B262E2FB401006B0F89 /* AppInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInspector.swift; sourceTree = "<group>"; };
+		BAC04B272E2FB401006B0F89 /* InspectConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectConstants.swift; sourceTree = "<group>"; };
 		CC21904A2A7B994A00269525 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		CC21904D2A7BC3E000269525 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		CC21904F2A7BC9FE00269525 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
@@ -185,6 +214,7 @@
 		CCD8ACEB2A011C9500D98695 /* RadioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioView.swift; sourceTree = "<group>"; };
 		CCE934AC2ACC29F60094BD06 /* TextFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFileView.swift; sourceTree = "<group>"; };
 		CCF430592C07562D004DFB4D /* DebugOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOverlay.swift; sourceTree = "<group>"; };
+		F9F647DDE9CB42EBA9D931B9 /* FileSystemCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -373,6 +403,7 @@
 		41C8259825F99AF90042DC50 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				BAC04B1D2E2FB3E6006B0F89 /* Inspect */,
 				4116922A28939A6C00A88700 /* ConstructionKit */,
 				414550A927C799D000D756E3 /* BackgroundBlur.swift */,
 				4154C2DF25F76BDB00A3D373 /* ContentView.swift */,
@@ -415,6 +446,24 @@
 			path = dialog;
 			sourceTree = "<group>";
 		};
+		BAC04B1D2E2FB3E6006B0F89 /* Inspect */ = {
+			isa = PBXGroup;
+			children = (
+				BAC04B152E2FB3E6006B0F89 /* FSEventsInspector.swift */,
+				BAC04B162E2FB3E6006B0F89 /* InspectLayoutProtocol.swift */,
+				BAC04B172E2FB3E6006B0F89 /* InspectState.swift */,
+				BAC04B182E2FB3E6006B0F89 /* InspectView.swift */,
+				0E97D6F92AD54BE3B1A5466D /* InspectValidationService.swift */,
+				159C2690A9E64B5C96D813D8 /* InspectConfigurationService.swift */,
+				BAC04B192E2FB3E6006B0F89 /* Preset1Layout.swift */,
+				BAC04B1A2E2FB3E6006B0F89 /* Preset2Layout.swift */,
+				BAC04B1B2E2FB3E6006B0F89 /* Preset3Layout.swift */,
+				BAC04B1C2E2FB3E6006B0F89 /* Preset4Layout.swift */,
+				600393D08F1240E680E37403 /* Preset5Layout.swift */,
+			);
+			path = Inspect;
+			sourceTree = "<group>";
+		};
 		CC21904C2A7BC3BC00269525 /* Functions */ = {
 			isa = PBXGroup;
 			children = (
@@ -445,10 +494,14 @@
 		CC21905A2A7BD47800269525 /* App Processing */ = {
 			isa = PBXGroup;
 			children = (
+				BAC04B262E2FB401006B0F89 /* AppInspector.swift */,
+				BAC04B272E2FB401006B0F89 /* InspectConstants.swift */,
 				41D81E7025F845D200D1F7E1 /* AppState.swift */,
 				CC21905C2A7BD7D300269525 /* AppVariables.swift */,
 				CC9F8FEE2A5EC76400802A88 /* ImageProcessing.swift */,
 				41D6FE8426DB11BA0083BE61 /* jamfHelper.swift */,
+				A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */,
+				F9F647DDE9CB42EBA9D931B9 /* FileSystemCache.swift */,
 			);
 			path = "App Processing";
 			sourceTree = "<group>";
@@ -495,7 +548,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				418A7B5B275994AD00E4D6F1 /* PBXTargetDependency */,
 			);
 			name = Dialog;
 			packageProductDependencies = (
@@ -665,6 +717,8 @@
 				418A7B532759949A00E4D6F1 /* TextEntryView.swift in Sources */,
 				CCB334702B2320F20079FB83 /* SolidColourView.swift in Sources */,
 				CC21905F2A7BD7F200269525 /* CommandLineArguments.swift in Sources */,
+				BAC04B282E2FB401006B0F89 /* AppInspector.swift in Sources */,
+				BAC04B292E2FB401006B0F89 /* InspectConstants.swift in Sources */,
 				CCE934AD2ACC29F60094BD06 /* TextFileView.swift in Sources */,
 				418A7B542759949A00E4D6F1 /* TimerView.swift in Sources */,
 				4116923B2893A22300A88700 /* CKListView.swift in Sources */,
@@ -674,6 +728,17 @@
 				CC7D44082B9C6FB5004B9E65 /* ImageFader.swift in Sources */,
 				418A7B572759949B00E4D6F1 /* ProcessCLOptions.swift in Sources */,
 				411692382893A21500A88700 /* CKImageView.swift in Sources */,
+				BAC04B1E2E2FB3E6006B0F89 /* Preset3Layout.swift in Sources */,
+				BAC04B1F2E2FB3E6006B0F89 /* Preset2Layout.swift in Sources */,
+				BAC04B202E2FB3E6006B0F89 /* Preset1Layout.swift in Sources */,
+				BAC04B212E2FB3E6006B0F89 /* InspectLayoutProtocol.swift in Sources */,
+				BAC04B222E2FB3E6006B0F89 /* InspectState.swift in Sources */,
+				BAC04B232E2FB3E6006B0F89 /* Preset4Layout.swift in Sources */,
+				600393D08F1240E680E37402 /* Preset5Layout.swift in Sources */,
+				BAC04B242E2FB3E6006B0F89 /* FSEventsInspector.swift in Sources */,
+				BAC04B252E2FB3E6006B0F89 /* InspectView.swift in Sources */,
+				0E97D6F92AD54BE3B1A5467D /* InspectValidationService.swift in Sources */,
+				159C2690A9E64B5C96D813E8 /* InspectConfigurationService.swift in Sources */,
 				CC2190522A7BCC3A00269525 /* Images.swift in Sources */,
 				418A7B582759949B00E4D6F1 /* NSWindow+Additions.swift in Sources */,
 				418A7B592759949B00E4D6F1 /* HelpText.swift in Sources */,
@@ -709,6 +774,9 @@
 				41D81E6C25F8209F00D1F7E1 /* CLOptions.swift in Sources */,
 				CC8D96302A01CCAB00CC84C6 /* Theme+sdMarkdown.swift in Sources */,
 				41D81E7125F845D200D1F7E1 /* AppState.swift in Sources */,
+				A78ED8A6E0EB427D86FCB769 /* MonitoringConstants.swift in Sources */,
+				927EC2B71BCB4E698795A084 /* DebouncedUpdater.swift in Sources */,
+				B4608E5B819446BC9AADDC8F /* FileSystemCache.swift in Sources */,
 				412B26AF289CE02100493EFF /* MiniView.swift in Sources */,
 				CC21905D2A7BD7D300269525 /* AppVariables.swift in Sources */,
 				4124EFD229455861003B00F4 /* HelpView.swift in Sources */,
@@ -746,10 +814,6 @@
 			isa = PBXTargetDependency;
 			target = 4154C2D925F76BDB00A3D373 /* Dialog */;
 			targetProxy = 4154C2F825F76BDC00A3D373 /* PBXContainerItemProxy */;
-		};
-		418A7B5B275994AD00E4D6F1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 418A7B5A275994AD00E4D6F1 /* MarkdownUI */;
 		};
 /* End PBXTargetDependency section */
 
@@ -905,7 +969,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
-				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				DEVELOPMENT_TEAM = D6G4X4D7C9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -934,7 +998,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
-				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				DEVELOPMENT_TEAM = D6G4X4D7C9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -1100,7 +1164,7 @@
 			repositoryURL = "https://github.com/gonzalezreal/MarkdownUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1110,11 +1174,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 414CBAE9278913BA00A1A980 /* XCRemoteSwiftPackageReference "SwiftyJSON" */;
 			productName = SwiftyJSON;
-		};
-		418A7B5A275994AD00E4D6F1 /* MarkdownUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 41E4BC9526AEDB130042A0A3 /* XCRemoteSwiftPackageReference "MarkdownUI" */;
-			productName = MarkdownUI;
 		};
 		418A7B5C275994BB00E4D6F1 /* MarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dialog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/MarkdownUI",
       "state" : {
-        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
-        "version" : "2.3.0"
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
         "version" : "6.0.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703",
+        "version" : "0.6.0"
       }
     },
     {

--- a/dialog/App Processing/AppInspector.swift
+++ b/dialog/App Processing/AppInspector.swift
@@ -1,0 +1,256 @@
+//
+//  AppInspector.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann on 19/7/2025.
+//
+
+import Foundation
+
+// MARK: - Protocol Definitions for Dependency Injection
+protocol FileSystemMonitorProtocol {
+    func startMonitoring(paths: [String])
+    func stopMonitoring()
+}
+
+protocol CommandFileWriterProtocol {
+    func writeCommand(_ command: String)
+}
+
+// MARK: - AppInspector: Real-time filesystem monitoring for monitor mode
+class AppInspector {
+    struct AppConfig: Codable {
+        struct App: Codable {
+            let id: String
+            let displayName: String
+            let guiIndex: Int
+            let paths: [String]
+        }
+        let apps: [App]
+        let cachePaths: [String]?
+    }
+    
+    // MARK: - Properties
+    private var config: AppConfig?
+    private var lastStatus: [String: Bool] = [:]
+    private var lastCachedStatus: [String: Bool] = [:]
+    private let checkInterval: TimeInterval = 2.0
+    private let commandFile: String
+    private var fsEventStream: FSEventStreamRef?
+    private let fileSystemCache = FileSystemCache()
+    
+    // MARK: - Initialization
+    init(commandFile: String = InspectConstants.commandFilePath) {
+        self.commandFile = commandFile
+        initCommandFile()
+    }
+    
+    // MARK: - Private Methods
+    private func initCommandFile() {
+        // Ensure we have the absolute path for the command file
+        let absolutePath = commandFile.hasPrefix("/") ? commandFile : InspectConstants.commandFilePath
+        
+        // Ensure command file exists and is writable
+        FileManager.default.createFile(atPath: absolutePath, contents: nil, attributes: [
+            .posixPermissions: 0o666
+        ])
+        writeLog("AppInspector: Initialized command file at \(absolutePath)", logLevel: .debug)
+    }
+    
+    private func writeCommand(_ command: String) {
+        // Ensure we have the absolute path for the command file
+        let absolutePath = commandFile.hasPrefix("/") ? commandFile : InspectConstants.commandFilePath
+        
+        do {
+            let data = (command + "\n").data(using: .utf8)!
+            let url = URL(fileURLWithPath: absolutePath)
+            
+            if FileManager.default.fileExists(atPath: absolutePath) {
+                let fileHandle = try FileHandle(forWritingTo: url)
+                defer { fileHandle.closeFile() }
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(data)
+            } else {
+                try data.write(to: url)
+            }
+            writeLog("AppInspector: Command written to \(absolutePath): \(command)", logLevel: .debug)
+        } catch {
+            writeLog("AppInspector: Failed to write command to \(absolutePath): \(error)", logLevel: .error)
+        }
+    }
+    
+    private func checkInstalled(_ paths: [String]) -> Bool {
+        for path in paths {
+            if FileManager.default.fileExists(atPath: path) {
+                return true
+            }
+        }
+        return false
+    }
+    
+    private func checkCacheForApp(_ app: AppConfig.App) -> Bool {
+        guard let cachePaths = config?.cachePaths else { return false }
+        
+        let appIdLower = app.id.lowercased()
+        let appNameLower = app.displayName.lowercased().replacingOccurrences(of: " ", with: "")
+        
+        // Use the optimized containsMatchingFile method to avoid unnecessary memory allocations  
+        for cachePath in cachePaths {
+            let hasMatchingFile = fileSystemCache.containsMatchingFile(in: cachePath) { file in
+                let lowercaseFile = file.lowercased()
+                let appIdMatch = lowercaseFile.contains(appIdLower)
+                let nameMatch = lowercaseFile.contains(appNameLower)
+                let isDownloadFile = lowercaseFile.hasSuffix(".download") || 
+                                    lowercaseFile.hasSuffix(".pkg") || 
+                                    lowercaseFile.hasSuffix(".dmg")
+                
+                return (appIdMatch || nameMatch) && isDownloadFile
+            }
+            
+            if hasMatchingFile {
+                return true
+            }
+        }
+        return false
+    }
+    
+    private func checkAndReport() {
+        guard let apps = config?.apps else { return }
+        
+        var totalInstalled = 0
+        var changes: [(index: Int, name: String, installed: Bool, cached: Bool)] = []
+        
+        for app in apps {
+            let isInstalled = checkInstalled(app.paths)
+            let isCached = checkCacheForApp(app)
+            let wasInstalled = lastStatus[app.id] ?? false
+            let wasCached = lastCachedStatus[app.id] ?? false
+            
+            if isInstalled {
+                totalInstalled += 1
+            }
+            
+            // Report installation status changes
+            if isInstalled != wasInstalled {
+                changes.append((app.guiIndex, app.displayName, isInstalled, isCached))
+                lastStatus[app.id] = isInstalled
+            }
+            
+            // Report cache status changes (downloads starting/stopping)
+            if isCached != wasCached && !isInstalled {
+                changes.append((app.guiIndex, app.displayName, false, isCached))
+                lastCachedStatus[app.id] = isCached
+            }
+        }
+        
+        // Write dialog commands for status updates
+        for change in changes {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "HH:mm:ss"
+            let timeStr = formatter.string(from: Date())
+            
+            if change.installed {
+                writeCommand("listitem: index: \(change.index), status: success, statustext: Installed (\(timeStr))")
+                writeCommand("progresstext: \(change.name) successfully installed")
+                writeCommand("progress: increment")
+                writeLog("AppInspector: INSTALLED \(change.name)", logLevel: .info)
+            } else if change.cached {
+                writeCommand("listitem: index: \(change.index), status: wait, statustext: Downloading...")
+                writeCommand("progresstext: \(change.name) downloading")
+                writeLog("AppInspector: DOWNLOADING \(change.name)", logLevel: .info)
+            } else {
+                writeCommand("listitem: index: \(change.index), status: pending, statustext: Pending")
+                writeLog("AppInspector: PENDING \(change.name)", logLevel: .info)
+            }
+        }
+        
+        // Check if complete
+        if totalInstalled == apps.count {
+            writeCommand("progresstext: All applications successfully installed!")
+            writeCommand("progress: complete")
+            writeLog("AppInspector: All applications installed", logLevel: .info)
+        }
+    }
+    
+    private func setupFSEvents() {
+        var pathsToMonitor = [InspectConstants.applicationsPath, InspectConstants.libraryApplicationSupportPath]
+        
+        // Add cache paths from config
+        if let cachePaths = config?.cachePaths {
+            pathsToMonitor.append(contentsOf: cachePaths)
+        }
+        
+        // Filter to existing paths
+        let existingPaths = pathsToMonitor.filter { FileManager.default.fileExists(atPath: $0) }
+        
+        writeLog("AppInspector: Monitoring \(existingPaths.count) filesystem paths", logLevel: .debug)
+        
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+        
+        let callback: FSEventStreamCallback = { _, clientCallBackInfo, _, _, _, _ in
+            if let info = clientCallBackInfo {
+                let monitor = Unmanaged<AppInspector>.fromOpaque(info).takeUnretainedValue()
+                // Trigger immediate check on filesystem change
+                DispatchQueue.main.async {
+                    monitor.checkAndReport()
+                }
+            }
+        }
+        
+        if let stream = FSEventStreamCreate(
+            nil,
+            callback,
+            &context,
+            existingPaths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            InspectConstants.fsEventsLatency,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents)
+        ) {
+            FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+            FSEventStreamStart(stream)
+            fsEventStream = stream
+        }
+    }
+    
+    // MARK: - Public Interface
+    func loadConfig(from jsonPath: String) {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: jsonPath)),
+              let loadedConfig = try? JSONDecoder().decode(AppConfig.self, from: data) else {
+            writeLog("AppInspector: Could not load config from \(jsonPath)", logLevel: .error)
+            return
+        }
+        
+        config = loadedConfig
+        writeLog("AppInspector: Loaded \(loadedConfig.apps.count) apps from config", logLevel: .info)
+    }
+    
+    func start() {
+        guard config != nil else {
+            writeLog("AppInspector: No config loaded, cannot start monitoring", logLevel: .error)
+            return
+        }
+        
+        writeLog("AppInspector: Starting filesystem monitoring", logLevel: .info)
+        
+        // Initial check
+        checkAndReport()
+        
+        // Setup periodic checks
+        Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: true) { [weak self] _ in
+            self?.checkAndReport()
+        }
+        
+        // Setup FSEvents for real-time detection
+        setupFSEvents()
+    }
+    
+    // MARK: - Cleanup
+    deinit {
+        if let stream = fsEventStream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+    }
+}

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -168,4 +168,7 @@ struct AppVariables {
     // debug flag
     var debugMode                       = Bool(false)
     var debugBorderColour               = Color.clear
+    
+    // inspect mode config path
+    var inspectConfigPath               = String("")
 }

--- a/dialog/App Processing/DebouncedUpdater.swift
+++ b/dialog/App Processing/DebouncedUpdater.swift
@@ -1,0 +1,65 @@
+//
+//  DebouncedUpdater.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann on 19/7/2025.
+//
+
+import Foundation
+
+/// Utility class for debouncing UI updates to improve performance
+class DebouncedUpdater {
+    private var workItems: [String: DispatchWorkItem] = [:]
+    private let delay: TimeInterval
+    private let queue: DispatchQueue
+    
+    /// Initialize debounced updater
+    /// - Parameters:
+    ///   - delay: Delay in seconds before executing the action (default: InspectConstants.debounceDelay)
+    ///   - queue: Queue to execute the action on (default: main queue)
+    init(delay: TimeInterval = InspectConstants.debounceDelay, queue: DispatchQueue = .main) {
+        self.delay = delay
+        self.queue = queue
+    }
+    
+    /// Debounce an action with a specific key
+    /// - Parameters:
+    ///   - key: Unique key for this debounced action
+    ///   - action: The action to execute after the delay
+    func debounce(key: String, action: @escaping () -> Void) {
+        // Cancel previous work item for this key
+        workItems[key]?.cancel()
+        
+        // Create new work item
+        let workItem = DispatchWorkItem {
+            action()
+            // Clean up the work item after execution
+            self.workItems.removeValue(forKey: key)
+        }
+        
+        // Store the work item
+        workItems[key] = workItem
+        
+        // Schedule execution
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+    
+    /// Cancel all pending debounced actions
+    func cancelAll() {
+        for workItem in workItems.values {
+            workItem.cancel()
+        }
+        workItems.removeAll()
+    }
+    
+    /// Cancel a specific debounced action
+    /// - Parameter key: The key of the action to cancel
+    func cancel(key: String) {
+        workItems[key]?.cancel()
+        workItems.removeValue(forKey: key)
+    }
+    
+    deinit {
+        cancelAll()
+    }
+}

--- a/dialog/App Processing/FileSystemCache.swift
+++ b/dialog/App Processing/FileSystemCache.swift
@@ -1,0 +1,249 @@
+//
+//  FileSystemCache.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann on 19/7/2025.
+//
+
+import Foundation
+
+/// Intelligent file system cache that handles permission issues and missing directories
+class FileSystemCache {
+    
+    // MARK: - Cache Entry
+    private struct CacheEntry {
+        let contents: [String]
+        let timestamp: Date
+        let accessGranted: Bool
+        
+        var isValid: Bool {
+            return accessGranted && Date().timeIntervalSince(timestamp) < InspectConstants.cacheTimeout
+        }
+    }
+    
+    // MARK: - Properties
+    private var directoryCache: [String: CacheEntry] = [:]
+    private var accessiblePaths: Set<String> = []
+    private var inaccessiblePaths: Set<String> = []
+    private let cacheTimeout: TimeInterval
+    private let maxCacheEntries: Int
+    private let maxMemoryUsage: Int
+    private var currentMemoryUsage: Int = 0
+    
+    // MARK: - Initialization
+    init(
+        cacheTimeout: TimeInterval = InspectConstants.cacheTimeout,
+        maxCacheEntries: Int = InspectConstants.maxCacheEntries,
+        maxMemoryUsage: Int = InspectConstants.maxMemoryUsage
+    ) {
+        self.cacheTimeout = cacheTimeout
+        self.maxCacheEntries = maxCacheEntries
+        self.maxMemoryUsage = maxMemoryUsage
+    }
+    
+    // MARK: - Public Interface
+    
+    /// Get cached directory contents if available and valid
+    /// - Parameter path: Directory path to check
+    /// - Returns: Array of filenames if cached and valid, nil otherwise
+    func getCachedDirectoryContents(_ path: String) -> [String]? {
+        // Quick check for known inaccessible paths
+        if inaccessiblePaths.contains(path) {
+            return nil
+        }
+        
+        guard let cached = directoryCache[path], cached.isValid else {
+            return nil
+        }
+        
+        writeLog("FileSystemCache: Cache HIT for \(path) (\(cached.contents.count) files)", logLevel: .debug)
+        return cached.contents
+    }
+    
+    /// Cache directory contents with intelligent error handling
+    /// - Parameter path: Directory path to cache
+    /// - Returns: Array of filenames or empty array if inaccessible
+    @discardableResult
+    func cacheDirectoryContents(_ path: String) -> [String] {
+        // Skip if we know this path is inaccessible
+        if inaccessiblePaths.contains(path) {
+            return []
+        }
+        
+        // Check if directory exists first
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            writeLog("FileSystemCache: Directory does not exist: \(path)", logLevel: .debug)
+            markPathInaccessible(path, reason: "Directory does not exist")
+            return []
+        }
+        
+        // Try to read directory contents
+        do {
+            let contents = try FileManager.default.contentsOfDirectory(atPath: path)
+            
+            // Success - cache the results
+            setCachedDirectoryContents(path, contents: contents, accessGranted: true)
+            accessiblePaths.insert(path)
+            
+            writeLog("FileSystemCache: Successfully cached \(contents.count) files from \(path)", logLevel: .debug)
+            return contents
+            
+        } catch let error as NSError {
+            // Handle specific error types
+            let reason: String
+            switch error.code {
+            case NSFileReadNoPermissionError:
+                reason = "Permission denied"
+            case NSFileReadNoSuchFileError:
+                reason = "Directory not found"
+            default:
+                reason = "Error: \(error.localizedDescription)"
+            }
+            
+            writeLog("FileSystemCache: Cannot access \(path) - \(reason)", logLevel: .info)
+            markPathInaccessible(path, reason: reason)
+            return []
+        }
+    }
+    
+    /// Invalidate cache for specific path
+    /// - Parameter path: Path to invalidate
+    func invalidateCache(for path: String) {
+        if let entry = directoryCache.removeValue(forKey: path) {
+            currentMemoryUsage -= estimateMemoryUsage(for: entry.contents)
+            writeLog("FileSystemCache: Invalidated cache for \(path)", logLevel: .debug)
+        }
+    }
+    
+    /// Invalidate all cached data
+    func invalidateAll() {
+        directoryCache.removeAll()
+        currentMemoryUsage = 0
+        writeLog("FileSystemCache: Invalidated all cache entries", logLevel: .debug)
+    }
+    
+    /// Get cache statistics
+    func getStatistics() -> (entries: Int, memoryUsage: Int, accessiblePaths: Int, inaccessiblePaths: Int) {
+        return (
+            entries: directoryCache.count,
+            memoryUsage: currentMemoryUsage,
+            accessiblePaths: accessiblePaths.count,
+            inaccessiblePaths: inaccessiblePaths.count
+        )
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setCachedDirectoryContents(_ path: String, contents: [String], accessGranted: Bool) {
+        // Memory management - check limits
+        if currentMemoryUsage > maxMemoryUsage {
+            clearOldestEntries()
+        }
+        
+        if directoryCache.count >= maxCacheEntries {
+            removeOldestEntry()
+        }
+        
+        // Calculate memory usage for new entry
+        let memoryUsage = estimateMemoryUsage(for: contents)
+        
+        // Remove old entry if exists
+        if let oldEntry = directoryCache[path] {
+            currentMemoryUsage -= estimateMemoryUsage(for: oldEntry.contents)
+        }
+        
+        // Add new entry
+        directoryCache[path] = CacheEntry(
+            contents: contents,
+            timestamp: Date(),
+            accessGranted: accessGranted
+        )
+        currentMemoryUsage += memoryUsage
+    }
+    
+    private func markPathInaccessible(_ path: String, reason: String) {
+        inaccessiblePaths.insert(path)
+        accessiblePaths.remove(path)
+        
+        // Cache an empty result with access denied flag
+        setCachedDirectoryContents(path, contents: [], accessGranted: false)
+        
+        writeLog("FileSystemCache: Marked path inaccessible: \(path) (\(reason))", logLevel: .info)
+    }
+    
+    private func removeOldestEntry() {
+        guard let oldestKey = directoryCache.min(by: { $0.value.timestamp < $1.value.timestamp })?.key else {
+            return
+        }
+        
+        if let entry = directoryCache.removeValue(forKey: oldestKey) {
+            currentMemoryUsage -= estimateMemoryUsage(for: entry.contents)
+            writeLog("FileSystemCache: Removed oldest entry: \(oldestKey)", logLevel: .debug)
+        }
+    }
+    
+    private func clearOldestEntries() {
+        let sortedEntries = directoryCache.sorted { $0.value.timestamp < $1.value.timestamp }
+        let entriesToRemove = sortedEntries.prefix(directoryCache.count / 4) // Remove 25%
+        
+        for (key, entry) in entriesToRemove {
+            directoryCache.removeValue(forKey: key)
+            currentMemoryUsage -= estimateMemoryUsage(for: entry.contents)
+        }
+        
+        writeLog("FileSystemCache: Cleared \(entriesToRemove.count) oldest entries (memory cleanup)", logLevel: .debug)
+    }
+    
+    private func estimateMemoryUsage(for contents: [String]) -> Int {
+        return contents.reduce(0) { $0 + $1.utf8.count } + (contents.count * 64) // Rough estimate
+    }
+}
+
+// MARK: - Cache-aware Directory Operations
+extension FileSystemCache {
+    
+    /// Check if any files in directory match the given criteria with caching
+    /// - Parameters:
+    ///   - path: Directory path to search
+    ///   - matchCriteria: Closure that returns true if file matches
+    /// - Returns: True if any matching file found
+    func containsMatchingFile(in path: String, matchCriteria: (String) -> Bool) -> Bool {
+        let contents: [String]
+        
+        // Try cache first
+        if let cached = getCachedDirectoryContents(path) {
+            contents = cached
+        } else {
+            // Cache miss - read and cache
+            contents = cacheDirectoryContents(path)
+        }
+        
+        return contents.contains(where: matchCriteria)
+    }
+    
+    /// Get all accessible cache paths from configuration
+    /// - Parameter cachePaths: Array of potential cache paths
+    /// - Returns: Array of verified accessible paths
+    func getAccessibleCachePaths(from cachePaths: [String]?) -> [String] {
+        guard let cachePaths = cachePaths else { return [] }
+        
+        var accessible: [String] = []
+        
+        for path in cachePaths {
+            if accessiblePaths.contains(path) {
+                accessible.append(path)
+            } else if !inaccessiblePaths.contains(path) {
+                // Unknown path - test it
+                if !cacheDirectoryContents(path).isEmpty || 
+                   (FileManager.default.fileExists(atPath: path) && !inaccessiblePaths.contains(path)) {
+                    accessible.append(path)
+                }
+            }
+        }
+        
+        writeLog("FileSystemCache: \(accessible.count)/\(cachePaths.count) cache paths accessible", logLevel: .info)
+        return accessible
+    }
+}

--- a/dialog/App Processing/InspectConstants.swift
+++ b/dialog/App Processing/InspectConstants.swift
@@ -1,0 +1,54 @@
+//
+//  InspectConstants.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann on 19/7/2025.
+//
+
+import Foundation
+
+/// Central configuration constants for inspect functionality
+struct InspectConstants {
+    // MARK: - File Paths
+    static let commandFilePath = "/var/tmp/dialog.log"
+    static let tempConfigPath = "/tmp/appmonitor_config.json"
+    static let applicationsPath = "/Applications"
+    static let libraryApplicationSupportPath = "/Library/Application Support"
+    
+    // MARK: - Timing Configuration
+    static let fallbackTimerInterval: TimeInterval = 30.0
+    static let fsEventsLatency: TimeInterval = 0.1
+    static let cacheTimeout: TimeInterval = 60.0  // Increased from 10s to reduce memory churn
+    static let debounceDelay: TimeInterval = 0.1
+    static let updateTimerInterval: TimeInterval = 5.0
+    static let fileSystemCheckInterval: TimeInterval = 3.0
+    static let robustUpdateInterval: TimeInterval = 2.0
+    
+    // MARK: - UI Animation
+    static let standardAnimationDuration: TimeInterval = 0.3
+    static let longAnimationDuration: TimeInterval = 0.5
+    static let scaleAnimationDuration: TimeInterval = 0.2
+    
+    // MARK: - Performance Limits
+    static let maxRetryAttempts = 3
+    static let maxCacheEntries = 100
+    static let maxMemoryUsage = 10_000_000 // 10MB
+    
+    // MARK: - UI Layout
+    static let sideMessageInterval: TimeInterval = 10.0
+    static let progressCompletionDelay: TimeInterval = 2.0
+    
+    // MARK: - UI Scale Factors
+    static let miniScaleFactor: CGFloat = 0.75
+    static let defaultScaleFactor: CGFloat = 1.0
+    
+    // MARK: - Additional Delays
+    static let manualScrollTimeoutInterval: TimeInterval = 5.0
+    static let buttonStateUpdateDelay: TimeInterval = 1.0
+    static let retryMonitoringDelay: TimeInterval = 0.5
+    static let startupDelay: TimeInterval = 1.0
+    
+    // MARK: - Monitoring Configuration
+    static let inspectQueueQoS = DispatchQoS.background
+    static let inspectQueueLabel = "app.inspect"
+}

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -141,6 +141,10 @@ struct CommandLineArguments {
     var hideDefaultKeyboardAction = CommandlineArgument(long: "hidedefaultkeyboardaction", isbool: true)
     var alwaysReturnUserInput      = CommandlineArgument(long: "alwaysreturninput", isbool: true)
     var removeNotification        = CommandlineArgument(long: "remove", isbool: true)
+
+    // Inspect Mode Arguments
+    var inspectMode               = CommandlineArgument(long: "inspect-mode", isbool: true)
+    var inspectConfig             = CommandlineArgument(long: "inspect-config")
 }
 
 extension CommandlineArgument {
@@ -324,6 +328,8 @@ extension CommandLineArguments {
                     case "setAppIcon": self.setAppIcon = argument
                     case "removeNotification": self.removeNotification = argument
                     case "notificationIdentifier": self.notificationIdentifier = argument
+                    case "inspectMode": self.inspectMode = argument
+                    case "inspectConfig": self.inspectConfig = argument
                     default: break
                     }
                 }

--- a/dialog/Views/Inspect/FSEventsInspector.swift
+++ b/dialog/Views/Inspect/FSEventsInspector.swift
@@ -1,0 +1,226 @@
+//
+//  FSEventsInspector.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//  FSEvents monitoring system
+//
+
+import Foundation
+
+/// Protocol for FSEvents monitoring delegate callbacks
+/// Extends the existing FileSystemMonitorProtocol from AppInspector
+
+protocol FSEventsInspectorDelegate: AnyObject {
+    func appInstalled(_ appId: String, at path: String)
+    func appUninstalled(_ appId: String, at path: String)
+    func cacheFileCreated(_ path: String)
+    func cacheFileRemoved(_ path: String)
+}
+
+class FSEventsInspector {
+    
+    // MARK: - Properties
+    weak var delegate: FSEventsInspectorDelegate?
+    
+    private var fsEventStream: FSEventStreamRef?
+    private var monitoredApps: [InspectConfig.ItemConfig] = []
+    private var cachePaths: [String] = []
+    private var eventDebouncer = EventDebouncer()
+    private var pathToAppMap: [String: String] = [:] // path -> appId mapping for O(1) lookup
+    
+    // MARK: - Public Interface
+    
+    func startMonitoring(apps: [InspectConfig.ItemConfig], cachePaths: [String]) {
+        self.monitoredApps = apps
+        self.cachePaths = cachePaths
+        
+        buildCachePathMappings()
+        setupCacheFSEvents()
+        
+        writeLog("FSEventsInspector: Started cache-only monitoring for \(cachePaths.count) cache paths", logLevel: .info)
+    }
+    
+    func stopMonitoring() {
+        if let stream = fsEventStream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            fsEventStream = nil
+            
+            eventDebouncer.cleanupDebouncer()
+            
+            writeLog("FSEventsInspector: Stopped monitoring and cleaned up resources", logLevel: .info)
+        }
+    }
+    
+    // MARK: - Private Implementation
+    
+    private func buildCachePathMappings() {
+        pathToAppMap.removeAll()
+                
+        writeLog("FSEventsInspector: Cache-only monitoring - no path mappings needed", logLevel: .debug)
+    }
+    
+    private func setupCacheFSEvents() {
+        var pathsToWatch = Set<String>()
+        
+            for cachePath in cachePaths {
+            if FileManager.default.fileExists(atPath: cachePath) {
+                pathsToWatch.insert(cachePath)
+            }
+        }
+        
+        let pathsArray = Array(pathsToWatch)
+        guard !pathsArray.isEmpty else {
+            writeLog("FSEventsInspector: No cache paths to monitor", logLevel: .info)
+            return
+        }
+        
+        var context = FSEventStreamContext(
+            version: 0,
+            info: UnsafeMutableRawPointer(Unmanaged.passRetained(self).toOpaque()),
+            retain: nil,
+            release: { info in
+                if let info = info {
+                    Unmanaged<FSEventsInspector>.fromOpaque(info).release()
+                }
+            },
+            copyDescription: nil
+        )
+        
+        let callback: FSEventStreamCallback = { _, clientInfo, numEvents, eventPaths, eventFlags, eventIds in
+            guard let clientInfo = clientInfo else { return }
+            let monitor = Unmanaged<FSEventsInspector>.fromOpaque(clientInfo).takeUnretainedValue()
+            
+            let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as! [String]
+            
+            for i in 0..<numEvents {
+                let path = paths[i]
+                let flags = eventFlags[i]
+                
+                guard monitor.isMonitoredPath(path) else { continue }
+                
+                monitor.eventDebouncer.debounce(key: path, delay: 0.1) {
+                    monitor.handleOptimizedFSEvent(path: path, flags: flags)
+                }
+                
+                if i % 1000 == 0 {
+                    monitor.eventDebouncer.cleanupDebouncer()
+                }
+            }
+        }
+        
+        fsEventStream = FSEventStreamCreate(
+            nil,
+            callback,
+            &context,
+            pathsArray as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.1, 
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes)
+        )
+        
+        guard let stream = fsEventStream else {
+            writeLog("FSEventsInspector: Failed to create FSEventStream", logLevel: .error)
+            return
+        }
+        
+        FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+        FSEventStreamStart(stream)
+        
+        writeLog("FSEventsInspector: Started FSEvents monitoring \(pathsArray.count) paths", logLevel: .info)
+    }
+    
+    private func isMonitoredPath(_ path: String) -> Bool {
+        for cachePath in cachePaths {
+            if path.hasPrefix(cachePath) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    private func handleOptimizedFSEvent(path: String, flags: FSEventStreamEventFlags) {
+        DispatchQueue.main.async { [weak self] in
+            self?.processEvent(path: path, flags: flags)
+        }
+    }
+    
+    private func processEvent(path: String, flags: FSEventStreamEventFlags) {
+        let isCreated = flags & FSEventStreamEventFlags(kFSEventStreamEventFlagItemCreated) != 0
+        let isRemoved = flags & FSEventStreamEventFlags(kFSEventStreamEventFlagItemRemoved) != 0
+        
+        if isCreated {
+            handleFileCreated(at: path)
+        } else if isRemoved {
+            handleFileRemoved(at: path)
+        }
+    }
+    
+    private func handleFileCreated(at path: String) {
+        if isCacheFile(path) {
+            delegate?.cacheFileCreated(path)
+            writeLog("FSEventsInspector: Detected cache file creation - \(path)", logLevel: .debug)
+        }
+    }
+    
+    private func handleFileRemoved(at path: String) {       
+        if isCacheFile(path) {
+            delegate?.cacheFileRemoved(path)
+            writeLog("FSEventsInspector: Detected cache file removal - \(path)", logLevel: .debug)
+        }
+    }
+    
+    private func findAppIdForPath(_ path: String) -> String? {
+        if let appId = pathToAppMap[path] {
+            return appId
+        }
+        
+        for (monitoredPath, appId) in pathToAppMap {
+            if path.hasPrefix(monitoredPath) {
+                return appId
+            }
+        }
+        
+        return nil
+    }
+    
+    private func isCacheFile(_ path: String) -> Bool {
+        let lowercasePath = path.lowercased()
+        return lowercasePath.hasSuffix(".pkg") || 
+               lowercasePath.hasSuffix(".dmg") || 
+               lowercasePath.hasSuffix(".download")
+    }
+}
+
+// MARK: - Event Debouncer
+
+/// This should debounce potential rapid FSEvents to prevent excessive UI updates
+private class EventDebouncer {
+    private var pendingEvents: [String: DispatchWorkItem] = [:]
+    private let queue = DispatchQueue(label: "fs.events.debouncer", qos: .userInitiated)
+    
+    func debounce(key: String, delay: TimeInterval, action: @escaping () -> Void) {
+
+        pendingEvents[key]?.cancel()
+        
+        let workItem = DispatchWorkItem {
+            action()
+            DispatchQueue.main.async {
+                self.pendingEvents.removeValue(forKey: key)
+            }
+        }
+        
+        pendingEvents[key] = workItem
+        queue.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+    
+    func cleanupDebouncer() {
+        for workItem in pendingEvents.values {
+            workItem.cancel()
+        }
+        pendingEvents.removeAll()
+    }
+}

--- a/dialog/Views/Inspect/InspectConfigurationService.swift
+++ b/dialog/Views/Inspect/InspectConfigurationService.swift
@@ -1,0 +1,316 @@
+//
+//  InspectConfigurationService.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 25/07/2025
+//  Business logic service used for configuration loading and processing
+//
+
+import Foundation
+
+// MARK: - Configuration Models
+
+struct ConfigurationRequest {
+    let environmentVariable: String
+    let fallbackToTestData: Bool
+    
+    static let `default` = ConfigurationRequest(
+        environmentVariable: "DIALOG_INSPECT_CONFIG",
+        fallbackToTestData: true
+    )
+}
+
+struct ConfigurationResult {
+    let config: InspectConfig
+    let source: ConfigurationSource
+    let warnings: [String]
+}
+
+
+enum ConfigurationError: Error, LocalizedError {
+    case fileNotFound(path: String)
+    case invalidJSON(path: String, error: Error)
+    case missingEnvironmentVariable(name: String)
+    case testDataCreationFailed(error: Error)
+    
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path):
+            return "Configuration file not found at: \(path)"
+        case .invalidJSON(let path, let error):
+            return "Invalid JSON in configuration file \(path): \(error.localizedDescription)"
+        case .missingEnvironmentVariable(let name):
+            return "Environment variable '\(name)' not set and no fallback available"
+        case .testDataCreationFailed(let error):
+            return "Failed to create test configuration: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Configuration Service
+
+class InspectConfigurationService {
+    
+    // MARK: - Isnpect API
+    
+    /// Load configuration from environment variable or fallback to test data
+    func loadConfiguration(_ request: ConfigurationRequest = .default) -> Result<ConfigurationResult, ConfigurationError> {
+        // Required: get config path from environment
+        if let configPath = getConfigPath(from: request.environmentVariable) {
+            writeLog("ConfigurationService: Using config from environment: \(configPath)", logLevel: .info)
+            return loadConfigurationFromFile(at: configPath)
+        }
+        
+        // Check if fallback is allowed
+        guard request.fallbackToTestData else {
+            return .failure(.missingEnvironmentVariable(name: request.environmentVariable))
+        }
+        
+        writeLog("ConfigurationService: No config path provided, using test data", logLevel: .info)
+        return createTestConfiguration()
+    }
+    
+    /// Fallback: Load configuration from specific file path 
+    /// TODO: Reevaluate as this has been brittle - loading from file system to late to initialize UI accordingly
+    func loadConfigurationFromFile(at path: String) -> Result<ConfigurationResult, ConfigurationError> {
+        // Check if file exists
+        guard FileManager.default.fileExists(atPath: path) else {
+            return .failure(.fileNotFound(path: path))
+        }
+        
+        do {
+            // Load and parse JSON
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            let decoder = JSONDecoder()
+            let config = try decoder.decode(InspectConfig.self, from: data)
+            
+            // Validate and apply defaults
+            let processedConfig = applyConfigurationDefaults(to: config)
+            let warnings = validateConfiguration(processedConfig)
+            
+            writeLog("ConfigurationService: Successfully loaded configuration from \(path)", logLevel: .info)
+            writeLog("ConfigurationService: Loaded \(config.items.count) items", logLevel: .debug)
+            
+            return .success(ConfigurationResult(
+                config: processedConfig,
+                source: .file(path: path),
+                warnings: warnings
+            ))
+            
+        } catch let error {
+            writeLog("ConfigurationService: Configuration loading failed for \(path): \(error)", logLevel: .error)
+            return .failure(.invalidJSON(path: path, error: error))
+        }
+    }
+    
+    /// Fallback for Demo: Create test configuration for development/fallback
+    func createTestConfiguration() -> Result<ConfigurationResult, ConfigurationError> {
+        let testConfigJSON = """
+        {
+            "title": "Test Configuration",
+            "message": "Testing inspect mode",
+            "preset": "preset1",
+            "cachePaths": ["/tmp"],
+            "items": [
+                {
+                    "id": "test1",
+                    "displayName": "Test Item 1", 
+                    "guiIndex": 0,
+                    "paths": ["/Applications/Test1.app"]
+                },
+                {
+                    "id": "test2",
+                    "displayName": "Test Item 2",
+                    "guiIndex": 1, 
+                    "paths": ["/Applications/Test2.app"]
+                },
+                {
+                    "id": "test3",
+                    "displayName": "Test Item 3",
+                    "guiIndex": 2,
+                    "paths": ["/Applications/Test3.app"]
+                }
+            ]
+        }
+        """
+        
+        do {
+            guard let jsonData = testConfigJSON.data(using: .utf8) else {
+                throw NSError(domain: "TestDataError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create JSON data"])
+            }
+            
+            let config = try JSONDecoder().decode(InspectConfig.self, from: jsonData)
+            let processedConfig = applyConfigurationDefaults(to: config)
+            
+            writeLog("ConfigurationService: Created test configuration with \(config.items.count) items", logLevel: .debug)
+            
+            return .success(ConfigurationResult(
+                config: processedConfig,
+                source: .testData,
+                warnings: []
+            ))
+            
+        } catch let error {
+            return .failure(.testDataCreationFailed(error: error))
+        }
+    }
+    
+    // MARK: - Internal Helper Methods
+    
+    private func getConfigPath(from environmentVariable: String) -> String? {
+        guard let path = ProcessInfo.processInfo.environment[environmentVariable] else {
+            return nil
+        }
+        return path.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    private func applyConfigurationDefaults(to config: InspectConfig) -> InspectConfig {
+        // Apply configuration defaults and process the config
+        // TODO: This is where we would add more advanced post-processing logic
+        
+        // Sort items by guiIndex for consistent display
+        let processedConfig = config
+        // Note: InspectConfig is a struct, we can't modify it directly
+        
+        return processedConfig
+    }
+    
+    /// TODO: better validate configuration and return warnings - 
+    private func validateConfiguration(_ config: InspectConfig) -> [String] {
+        var warnings: [String] = []
+        
+        // Check for common configuration issues
+        if config.items.isEmpty && config.plistSources?.isEmpty != false {
+            warnings.append("Configuration has no items or plist sources")
+        }
+        
+        if let preset = config.preset, !["preset1", "preset2", "preset3", "preset4", "preset5"].contains(preset) {
+            warnings.append("Unknown preset '\(preset)' - will default to preset1")
+        }
+        
+        // Check for missing icon files
+        if let iconPath = config.icon, !FileManager.default.fileExists(atPath: iconPath) {
+            warnings.append("Icon file not found: \(iconPath)")
+        }
+        
+        // Check for missing background images
+        if let backgroundImage = config.backgroundImage, !FileManager.default.fileExists(atPath: backgroundImage) {
+            warnings.append("Background image not found: \(backgroundImage)")
+        }
+        
+        // Validate color thresholds
+        if let thresholds = config.colorThresholds {
+            if thresholds.excellent <= thresholds.good || thresholds.good <= thresholds.warning {
+                warnings.append("Color thresholds should be in descending order (excellent > good > warning)")
+            }
+        }
+        
+        // Log warnings
+        for warning in warnings {
+            writeLog("ConfigurationService: Warning - \(warning)", logLevel: .info)
+        }
+        
+        return warnings
+    }
+    
+    // MARK: - Configuration Transformation Helpers
+    
+    func extractUIConfiguration(from config: InspectConfig) -> UIConfiguration {
+        var uiConfig = UIConfiguration()
+        
+        if let title = config.title {
+            uiConfig.windowTitle = title
+        }
+        
+        if let message = config.message {
+            uiConfig.subtitleMessage = message
+            uiConfig.statusMessage = message
+        }
+        
+        if let icon = config.icon {
+            uiConfig.iconPath = icon
+        }
+        
+        if let sideMessage = config.sideMessage {
+            uiConfig.sideMessages = sideMessage
+        }
+        
+        if let popupButton = config.popupButton {
+            uiConfig.popupButtonText = popupButton
+        }
+        
+        if let preset = config.preset {
+            uiConfig.preset = preset
+        }
+        
+        if let highlightColor = config.highlightColor {
+            uiConfig.highlightColor = highlightColor
+        }
+        
+        if let iconsize = config.iconsize {
+            uiConfig.iconSize = iconsize
+        }
+        
+        return uiConfig
+    }
+    
+    func extractBackgroundConfiguration(from config: InspectConfig) -> BackgroundConfiguration {
+        var bgConfig = BackgroundConfiguration()
+        
+        if let backgroundColor = config.backgroundColor {
+            bgConfig.backgroundColor = backgroundColor
+        }
+        
+        if let backgroundImage = config.backgroundImage {
+            bgConfig.backgroundImage = backgroundImage
+        }
+        
+        if let backgroundOpacity = config.backgroundOpacity {
+            bgConfig.backgroundOpacity = backgroundOpacity
+        }
+        
+        if let textOverlayColor = config.textOverlayColor {
+            bgConfig.textOverlayColor = textOverlayColor
+        }
+        
+        if let gradientColors = config.gradientColors {
+            bgConfig.gradientColors = gradientColors
+        }
+        
+        return bgConfig
+    }
+    
+    func extractButtonConfiguration(from config: InspectConfig) -> ButtonConfiguration {
+        var buttonConfig = ButtonConfiguration()
+        
+        if let button1Text = config.button1Text {
+            buttonConfig.button1Text = button1Text
+        }
+        
+        if let button1Disabled = config.button1Disabled {
+            buttonConfig.button1Disabled = button1Disabled
+        }
+        
+        if let button2Text = config.button2Text {
+            buttonConfig.button2Text = button2Text
+        }
+        
+        if let button2Disabled = config.button2Disabled {
+            buttonConfig.button2Disabled = button2Disabled
+        }
+        
+        if let button2Visible = config.button2Visible {
+            buttonConfig.button2Visible = button2Visible
+        }
+        
+        if let buttonStyle = config.buttonStyle {
+            buttonConfig.buttonStyle = buttonStyle
+        }
+        
+        if let autoEnableButton = config.autoEnableButton {
+            buttonConfig.autoEnableButton = autoEnableButton
+        }
+        
+        return buttonConfig
+    }
+}

--- a/dialog/Views/Inspect/InspectLayoutProtocol.swift
+++ b/dialog/Views/Inspect/InspectLayoutProtocol.swift
@@ -1,0 +1,130 @@
+//
+//  InspectLayoutProtocol.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//
+
+import SwiftUI
+
+// MARK: - Protocol Definition
+
+protocol InspectLayoutProtocol {
+    associatedtype Body: View
+    
+    var inspectState: InspectState { get }
+    var isMini: Bool { get }
+    
+    @ViewBuilder var body: Body { get }
+}
+
+// MARK: - Protocol Extension
+
+extension InspectLayoutProtocol {
+    
+    // MARK: Properties
+    
+    var scaleFactor: CGFloat {
+        return isMini ? 0.75 : 1.0
+    }
+    
+    // MARK: Item Sorting
+    
+    func getSortedItemsByStatus() -> [InspectConfig.ItemConfig] {
+        let completedItems = inspectState.items.filter { inspectState.completedItems.contains($0.id) }
+        let downloadingItems = inspectState.items.filter { inspectState.downloadingItems.contains($0.id) }
+        let pendingItems = inspectState.items.filter { 
+            !inspectState.completedItems.contains($0.id) && !inspectState.downloadingItems.contains($0.id) 
+        }
+        
+        return completedItems + downloadingItems + pendingItems
+    }
+    
+    func getItemStatusType(for item: InspectConfig.ItemConfig) -> ItemStatusType {
+        if inspectState.completedItems.contains(item.id) {
+            return .completed
+        } else if inspectState.downloadingItems.contains(item.id) {
+            return .downloading
+        } else {
+            return .pending
+        }
+    }
+    
+    func getItemStatus(for item: InspectConfig.ItemConfig) -> String {
+        if inspectState.completedItems.contains(item.id) {
+            return "Installed"
+        } else if inspectState.downloadingItems.contains(item.id) {
+            return "Installing..."
+        } else {
+            return "Waiting"
+        }
+    }
+    
+    // MARK: UI Components
+    
+    @ViewBuilder
+    func buttonArea() -> some View {
+        HStack(spacing: 12) {
+            if inspectState.completedItems.count == inspectState.items.count && 
+               inspectState.buttonConfiguration.button2Visible && !inspectState.buttonConfiguration.button2Text.isEmpty {
+                Button(inspectState.buttonConfiguration.button2Text) {
+                    writeLog("InspectView: User clicked button2 (\(inspectState.buttonConfiguration.button2Text)) - exiting with code 2", logLevel: .info)
+                    exit(2)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(inspectState.buttonConfiguration.button2Disabled)
+            }
+            
+            Button(inspectState.buttonConfiguration.button1Text) {
+                writeLog("InspectView: User clicked button1 (\(inspectState.buttonConfiguration.button1Text)) - exiting with code 0", logLevel: .info)
+                exit(0)
+            }
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(inspectState.buttonConfiguration.button1Disabled)
+        }
+    }
+    
+    @ViewBuilder
+    func itemIcon(for item: InspectConfig.ItemConfig, size: CGFloat) -> some View {
+        if let iconPath = item.icon,
+           FileManager.default.fileExists(atPath: iconPath) {
+            Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size, height: size)
+        } else {
+            Image(systemName: "app.fill")
+                .font(.system(size: size * 0.75))
+                .foregroundColor(.blue)
+                .frame(width: size, height: size)
+        }
+    }
+    
+    @ViewBuilder
+    func statusIndicator(for item: InspectConfig.ItemConfig) -> some View {
+        if inspectState.completedItems.contains(item.id) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.title2)
+        } else if inspectState.downloadingItems.contains(item.id) {
+            ProgressView()
+                .scaleEffect(0.8)
+                .frame(width: 20 * scaleFactor, height: 20 * scaleFactor)
+        } else {
+            Circle()
+                .strokeBorder(Color.gray.opacity(0.3), lineWidth: 2)
+                .frame(width: 24 * scaleFactor, height: 24 * scaleFactor)
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+enum ItemStatusType {
+    case completed
+    case downloading  
+    case pending
+}

--- a/dialog/Views/Inspect/InspectState.swift
+++ b/dialog/Views/Inspect/InspectState.swift
@@ -1,0 +1,761 @@
+//
+//  InspectState.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//
+
+import Foundation
+import SwiftUI
+
+enum LoadingState {
+    case loading
+    case loaded
+    case failed(String)
+}
+
+enum ConfigurationSource {
+    case file(path: String)
+    case testData
+    case fallback
+}
+
+// MARK: - Configuration Structs for Grouped State
+
+struct UIConfiguration {
+    var windowTitle: String = "System Inspection"
+    var statusMessage: String = "Inspection active - Items will appear as they are detected"
+    var iconPath: String? = nil
+    var sideMessages: [String] = []
+    var currentSideMessageIndex: Int = 0
+    var popupButtonText: String = "Install details..."
+    var preset: String = "preset1"
+    var highlightColor: String = "#808080"
+    var iconSize: Int = 120
+    var subtitleMessage: String? = nil
+}
+
+struct BackgroundConfiguration {
+    var backgroundColor: String? = nil
+    var backgroundImage: String? = nil
+    var backgroundOpacity: Double = 1.0
+    var textOverlayColor: String? = nil
+    var gradientColors: [String] = []
+}
+
+struct ButtonConfiguration {
+    var button1Text: String = "OK"
+    var button1Disabled: Bool = false
+    var button2Text: String = "Cancel"
+    var button2Disabled: Bool = false
+    var button2Visible: Bool = true
+    var buttonStyle: String = "default"
+    var autoEnableButton: Bool = true
+}
+
+class InspectState: ObservableObject, FSEventsInspectorDelegate {
+    // MARK: - Core State (Keep as @Published)
+    @Published var loadingState: LoadingState = .loading
+    @Published var items: [InspectConfig.ItemConfig] = []
+    @Published var config: InspectConfig?
+    
+    // MARK: - Grouped Configuration State
+    @Published var uiConfiguration = UIConfiguration()
+    @Published var backgroundConfiguration = BackgroundConfiguration()
+    @Published var buttonConfiguration = ButtonConfiguration()
+    
+    // MARK: - Preset-specific State
+    @Published var plistSources: [InspectConfig.PlistSourceConfig]? = nil
+    @Published var colorThresholds: InspectConfig.ColorThresholds = InspectConfig.ColorThresholds.default
+    @Published var plistValidationResults: [String: Bool] = [:] // Track plist validation results
+    
+    // MARK: - View-specific State (Should be @State in views, but keeping for now)
+    @Published var scrollOffset: Int = 0 // Manual scroll offset, currently needed in preset3
+    @Published var lastManualScrollTime: Date? = nil // Track manual scrolling
+    
+    // MARK: - Dynamic State (Needs @Published for UI updates)
+    @Published var completedItems: Set<String> = []
+    @Published var downloadingItems: Set<String> = []
+    
+    private var appInspector: AppInspector?
+    private var configPath: String?
+    private var lastCommandFileSize: Int = 0
+    private var lastProcessedLineCount: Int = 0
+    private var commandFileMonitor: DispatchSourceFileSystemObject?
+    private var updateTimer: Timer?
+    private var fileSystemCheckTimer: Timer?
+    private var sideMessageTimer: Timer?
+    private var debouncedUpdater = DebouncedUpdater()
+    private let fileSystemCache = FileSystemCache()
+    
+    private let fsEventsMonitor = FSEventsInspector()
+    private var lastFSEventTime: Date?
+    private var lastLogTime: Date = Date()
+    
+    // MARK: - Base Business Logic Services initialize
+    private let validationService = InspectValidationService()
+    private let configurationService = InspectConfigurationService()
+    
+    func initialize() {
+        writeLog("InspectState.initialize() - Starting initialization", logLevel: .info)
+        
+        loadConfiguration()
+        startMonitoring()
+        
+        writeLog("InspectState: Memory-safe initialization complete", logLevel: .info)
+    }
+    
+    private func loadConfiguration() {
+        // Use configuration service to load config
+        let result = configurationService.loadConfiguration()
+        
+        switch result {
+        case .success(let configResult):
+            // Log warnings from configuration validation 
+            // TODO: Learn how best type-chcek in swift
+            for warning in configResult.warnings {
+                writeLog("InspectState: Configuration warning - \(warning)", logLevel: .info)
+            }
+            
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                
+                let loadedConfig = configResult.config
+                
+                // Set core configuration
+                self.config = loadedConfig
+                self.items = loadedConfig.items.sorted { $0.guiIndex < $1.guiIndex }
+                
+                // Set plist sources from config - required inpreset5
+                self.plistSources = loadedConfig.plistSources
+                
+                // Set color thresholds from config or use defaults
+                if let colorThresholds = loadedConfig.colorThresholds {
+                    self.colorThresholds = colorThresholds
+                    writeLog("InspectState: Using custom color thresholds - Excellent: \(colorThresholds.excellent), Good: \(colorThresholds.good), Warning: \(colorThresholds.warning)", logLevel: .info)
+                } else {
+                    self.colorThresholds = InspectConfig.ColorThresholds.default
+                    writeLog("InspectState: Using default color thresholds", logLevel: .info)
+                }
+                
+                // Use configuration service to extract grouped configurations
+                self.uiConfiguration = self.configurationService.extractUIConfiguration(from: loadedConfig)
+                self.backgroundConfiguration = self.configurationService.extractBackgroundConfiguration(from: loadedConfig)
+                self.buttonConfiguration = self.configurationService.extractButtonConfiguration(from: loadedConfig)
+                
+                // Set side message rotation if multiple messages exist
+                if self.uiConfiguration.sideMessages.count > 1, let interval = loadedConfig.sideInterval {
+                    self.startSideMessageRotation(interval: TimeInterval(interval))
+                }
+                
+                // Debug logging for preset detection
+                if appvars.debugMode { print("DEBUG: loadedConfig.preset = \(loadedConfig.preset ?? "nil")") }
+                if appvars.debugMode { print("DEBUG: Setting preset to: \(self.uiConfiguration.preset)") }
+                
+                writeLog("InspectState: Loaded \(loadedConfig.items.count) items from config", logLevel: .info)
+                writeLog("InspectState: Title: \(self.uiConfiguration.windowTitle)", logLevel: .debug)
+                writeLog("InspectState: Using preset: \(self.uiConfiguration.preset)", logLevel: .info)
+                if !self.uiConfiguration.sideMessages.isEmpty {
+                    writeLog("InspectState: Side messages: \(self.uiConfiguration.sideMessages.count)", logLevel: .debug)
+                }
+                
+                // Log configuration source
+                switch configResult.source {
+                case .file(let path):
+                    writeLog("InspectState: Configuration loaded from file: \(path)", logLevel: .info)
+                    self.configPath = path
+                case .testData:
+                    writeLog("InspectState: Using fallback test data configuration", logLevel: .info)
+                case .fallback:
+                    writeLog("InspectState: Using fallback configuration", logLevel: .info)
+                }
+                
+                // Here, configuration loaded successfully
+                self.loadingState = .loaded
+                
+                // Validate items to populate results dict
+                self.validateAllItems()
+                
+                // Once config is loaded, start FSEvents monitoring for UI updates
+                self.setupOptimizedFSEventsInspectoring()
+            }
+            
+        case .failure(let error):
+            writeLog("InspectState: Configuration loading failed - \(error.localizedDescription)", logLevel: .error)
+            DispatchQueue.main.async { [weak self] in
+                self?.loadingState = .failed(error.localizedDescription)
+            }
+        }
+    }
+    
+    
+    func retryConfiguration() {
+        DispatchQueue.main.async { [weak self] in
+            self?.loadingState = .loading
+        }
+        loadConfiguration()
+    }
+    
+    
+    private func startMonitoring() {
+        writeLog("InspectState.startMonitoring() - Starting all monitoring components", logLevel: .info)
+        
+        // Create AppInspector for filesystem monitoring
+        appInspector = AppInspector()
+        
+        // Next, configure AppInspector if we have config data
+        if let config = config {
+            loadAppInspectConfig(config: config, originalPath: configPath ?? "")
+        }
+        
+        // Setup command file monitoring for continued status updates
+        setupCommandFileMonitoring()
+        
+        // Setup periodic updates as backup detection method
+        setupOptimizedPeriodicUpdates()
+        
+        // Setup FSEvents monitoring for cache file detection
+        setupOptimizedFSEventsInspectoring()
+        
+        writeLog("InspectState: All monitoring components started successfully", logLevel: .info)
+    }
+    
+    private func setupCommandFileMonitoring() {
+        // Look into this for memory-safety checks - our command file monitoring setup is sensitive, we want avoid leaks
+        let commandFilePath = InspectConstants.commandFilePath
+        
+        guard FileManager.default.fileExists(atPath: commandFilePath) else {
+            writeLog("InspectState: Command file doesn't exist yet: \(commandFilePath)", logLevel: .debug)
+            return
+        }
+        
+        // Prevent multiple monitoring setups
+        guard commandFileMonitor == nil else {
+            writeLog("InspectState: Command file monitoring already set up", logLevel: .debug)
+            return
+        }
+        
+        // Create command file monitor with weak self to prevent retain cycles
+        let fileHandle = open(commandFilePath, O_EVTONLY)
+        guard fileHandle >= 0 else {
+            writeLog("InspectState: Unable to open command file for monitoring: \(commandFilePath)", logLevel: .error)
+            return
+        }
+        
+        commandFileMonitor = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileHandle,
+            eventMask: .write,
+            queue: DispatchQueue.global(qos: .utility)
+        )
+        
+        commandFileMonitor?.setEventHandler { [weak self] in
+            // Use weak self to prevent memory leaks in nested closures
+            guard let self = self else { return }
+            self.debouncedUpdater.debounce(key: "command-file-update") { [weak self] in
+                self?.updateAppStatus()
+            }
+        }
+        
+        commandFileMonitor?.setCancelHandler {
+            close(fileHandle)
+        }
+        
+        commandFileMonitor?.resume()
+        writeLog("DispatchSource file monitoring active", logLevel: .info)
+    }
+    
+    private func setupOptimizedPeriodicUpdates() {
+        // Periodic updates with weak self references
+        updateTimer?.invalidate()
+        
+        updateTimer = Timer.scheduledTimer(withTimeInterval: InspectConstants.robustUpdateInterval, repeats: true) { [weak self] _ in
+            // Again, use weak self to prevent memory leaks
+            self?.performRobustAppCheck()
+        }
+        
+        writeLog("Timer-based monitoring active", logLevel: .info)
+    }
+    
+    private func setupOptimizedFSEventsInspectoring() {
+        // Instantiate FSEvents monitoring setup
+        let cachePaths = config?.cachePaths ?? []
+        
+        guard !cachePaths.isEmpty else {
+            writeLog("InspectState: No cache paths configured for FSEvents monitoring", logLevel: .debug)
+            return
+        }
+        
+        // Set up FSEvents monitor with our delegate pattern
+        fsEventsMonitor.delegate = self
+        fsEventsMonitor.startMonitoring(apps: items, cachePaths: cachePaths)
+        
+        writeLog("FSEvents monitoring active", logLevel: .info)
+    }
+    
+    private func performRobustAppCheck() {
+        // Simple, timer-based monitoring - checks all app states every 2 seconds
+        // This ensures 100% reliability for detecting app installations
+        
+        // Only log every 30 seconds to avoid memory accumulation
+        if Date().timeIntervalSince(lastLogTime) > 30.0 {
+            writeLog("InspectState: App status monitoring active", logLevel: .debug)
+            lastLogTime = Date()
+        }
+        
+        // Always check command file for updates (external status changes)
+        checkCommandFileForUpdates()
+        
+        // Check all app installation statuses directly
+        checkDirectInstallationStatus()
+    }
+    
+    // MARK: - FSEventsInspectorDelegate Implementation (Cache-only)
+    
+    func appInstalled(_ appId: String, at path: String) {
+        // App installations are handled by robust timer polling
+        // FSEvents only used for pre-loaded cachePaths monitoring
+        writeLog("InspectState: FSEvents app install ignored - handled by timer polling", logLevel: .debug)
+    }
+    
+    func appUninstalled(_ appId: String, at path: String) {
+        // App uninstalls are handled by robust timer polling
+        // FSEvents only used for pre-loaded cachePaths  monitoring 
+        writeLog("InspectState: FSEvents app uninstall ignored - handled by timer polling", logLevel: .debug)
+    }
+    
+    func cacheFileCreated(_ path: String) {
+        lastFSEventTime = Date()
+        
+        // Check if this cache file indicates an app is downloading in our pre-loaded cachePaths
+        for item in items {
+            if !completedItems.contains(item.id) && cacheFileMatchesItem(path, item: item) {
+                debouncedUpdater.debounce(key: "fsevents-download-\(item.id)") { [weak self] in
+                    guard let self = self else { return }
+                    if !self.downloadingItems.contains(item.id) {
+                        self.downloadingItems.insert(item.id)
+                        writeLog("InspectState: FSEvents detected item downloading - \(item.id) from cache file \(path)", logLevel: .info)
+                    }
+                }
+                break
+            }
+        }
+    }
+    
+    func cacheFileRemoved(_ path: String) {
+        lastFSEventTime = Date()
+        writeLog("InspectState: FSEvents detected cache file removal - \(path)", logLevel: .debug)
+    }
+    
+    private func cacheFileMatchesItem(_ filePath: String, item: InspectConfig.ItemConfig) -> Bool {
+        let lowercaseFile = filePath.lowercased()
+        let itemIdLower = item.id.lowercased()
+        let itemNameLower = item.displayName.lowercased().replacingOccurrences(of: " ", with: "")
+        
+        let itemIdMatch = lowercaseFile.contains(itemIdLower)
+        let nameMatch = lowercaseFile.contains(itemNameLower)
+        
+        let isDownloadFile = lowercaseFile.hasSuffix(".download") || 
+                            lowercaseFile.hasSuffix(".pkg") || 
+                            lowercaseFile.hasSuffix(".dmg")
+        
+        return (itemIdMatch || nameMatch) && isDownloadFile
+    }
+    
+    private func updateAppStatus() {
+        // Check for command file updates and direct filesystem status
+        checkCommandFileForUpdates()
+        checkDirectInstallationStatus()
+    }
+    
+    private func checkCommandFileForUpdates() {
+        let commandFilePath = InspectConstants.commandFilePath
+        
+        guard FileManager.default.fileExists(atPath: commandFilePath) else {
+            return
+        }
+        
+        do {
+            let content = try String(contentsOfFile: commandFilePath)
+            let currentSize = content.count
+            let lines = content.components(separatedBy: .newlines)
+            let currentLineCount = lines.count
+            
+            // Only process if file has actually changed
+            if currentSize != lastCommandFileSize || currentLineCount != lastProcessedLineCount {
+                
+                // Process only new lines since last check (more efficient)
+                let newLines = Array(lines.dropFirst(max(0, lastProcessedLineCount)))
+                
+                if !newLines.isEmpty {
+                    writeLog("InspectState: Processing \(newLines.count) new command lines", logLevel: .debug)
+                    
+                    for line in newLines {
+                        if !line.isEmpty {
+                            parseCommandLine(line)
+                        }
+                    }
+                }
+                
+                lastCommandFileSize = currentSize
+                lastProcessedLineCount = currentLineCount
+                writeLog("InspectState: Command file updated (size: \(currentSize), lines: \(currentLineCount))", logLevel: .debug)
+            }
+        } catch {
+            writeLog("InspectState: Error reading command file: \(error)", logLevel: .error)
+        }
+    }
+    
+    private func checkDirectInstallationStatus() {
+        // Direct filesystem check - this is our backup detection method
+        guard !items.isEmpty else { return }
+        
+        var changesDetected = false
+        
+        for item in items {
+            let wasCompleted = completedItems.contains(item.id)
+            let wasDownloading = downloadingItems.contains(item.id)
+            
+            // Path checking - stop at first found path
+            let isInstalled = item.paths.first { path in
+                FileManager.default.fileExists(atPath: path)
+            } != nil
+            
+            // Only check cache if not already installed (for performance optimization)
+            let isDownloading = !isInstalled && checkCacheForItem(item)
+            
+            // Apply changes only if status actually changed
+            if isInstalled && !wasCompleted {
+                self.debouncedUpdater.debounce(key: "item-install-\(item.id)") {
+                    self.completedItems.insert(item.id)
+                    self.downloadingItems.remove(item.id)
+                    
+                    // Check if this was the last item to complete
+                    if self.completedItems.count == self.items.count {
+                        writeLog("InspectState: All items completed - triggering button state update", logLevel: .info)
+                        // Introduce a small delay to ensure UI state is updated
+                        DispatchQueue.main.asyncAfter(deadline: .now() + InspectConstants.debounceDelay) { [weak self] in
+                            self?.checkAndUpdateButtonState()
+                        }
+                    }
+                }
+                writeLog("InspectState: FILESYSTEM - \(item.displayName) detection completed", logLevel: .info)
+                changesDetected = true
+                
+            } else if !isInstalled && wasCompleted {
+                // App was installed but now deleted - check if still downloading
+                if isDownloading {
+                    self.debouncedUpdater.debounce(key: "item-download-\(item.id)") {
+                        self.completedItems.remove(item.id)
+                        self.downloadingItems.insert(item.id)
+                    }
+                    writeLog("InspectState: FILESYSTEM - \(item.displayName) deleted but still downloading", logLevel: .info)
+                } else {
+                    self.debouncedUpdater.debounce(key: "item-remove-\(item.id)") {
+                        self.completedItems.remove(item.id)
+                        self.downloadingItems.remove(item.id)
+                    }
+                    writeLog("InspectState: FILESYSTEM - \(item.displayName) deleted, reset to pending", logLevel: .info)
+                }
+                changesDetected = true
+                
+            } else if isDownloading && !wasDownloading {
+                self.debouncedUpdater.debounce(key: "item-downloading-\(item.id)") {
+                    self.downloadingItems.insert(item.id)
+                }
+                writeLog("InspectState: FILESYSTEM - \(item.displayName) downloading", logLevel: .info)
+                changesDetected = true
+                
+            } else if !isDownloading && !isInstalled && (wasDownloading || wasCompleted) {
+                self.debouncedUpdater.debounce(key: "item-pending-\(item.id)") {
+                    self.downloadingItems.remove(item.id)
+                    self.completedItems.remove(item.id)
+                }
+                writeLog("InspectState: FILESYSTEM - \(item.displayName) reset to pending", logLevel: .info)
+                changesDetected = true
+            }
+        }
+        
+        if changesDetected {
+            writeLog("InspectState: Filesystem check detected status changes", logLevel: .debug)
+        }
+    }
+    
+    private func loadAppInspectConfig(config: InspectConfig, originalPath: String) {
+        // Convert InspectConfig to AppInspector.AppConfig format
+        // TODO: Consolidate this with AppInspector/AppInspectorConfig structures
+        do {
+            // Create AppInspector compatible structure
+            let appInspectorApps = config.items.map { item in
+                return [
+                    "id": item.id,
+                    "displayName": item.displayName,
+                    "guiIndex": item.guiIndex,
+                    "paths": item.paths
+                ] as [String: Any]
+            }
+            
+            var appInspectConfig: [String: Any] = [
+                "apps": appInspectorApps
+            ]
+            
+            if let cachePaths = config.cachePaths {
+                appInspectConfig["cachePaths"] = cachePaths
+            }
+            
+            // Convert to JSON data and write to a temporary file for AppInspector to load
+            let jsonData = try JSONSerialization.data(withJSONObject: appInspectConfig, options: [])
+            let tempConfigPath = InspectConstants.tempConfigPath
+            try jsonData.write(to: URL(fileURLWithPath: tempConfigPath))
+            
+            // Load the converted config into AppInspector
+            appInspector?.loadConfig(from: tempConfigPath)
+            
+            // Start AppInspector filesystem monitoring
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.appInspector?.start()
+                writeLog("InspectState: AppInspector filesystem monitoring started", logLevel: .info)
+            }
+            
+            writeLog("InspectState: Successfully converted and loaded config for AppInspector", logLevel: .info)
+            
+        } catch {
+            writeLog("InspectState: Failed to convert config for AppInspector: \(error)", logLevel: .error)
+        }
+    }
+    
+    private func checkCacheForItem(_ item: InspectConfig.ItemConfig) -> Bool {
+        guard let config = config, let cachePaths = config.cachePaths else { return false }
+        
+        let itemIdLower = item.id.lowercased()
+        let itemNameLower = item.displayName.lowercased().replacingOccurrences(of: " ", with: "")
+        
+        // Use the optimized containsMatchingFile method to avoid unnecessary memory allocations
+        for cachePath in cachePaths {
+            let hasMatchingFile = fileSystemCache.containsMatchingFile(in: cachePath) { file in
+                let lowercaseFile = file.lowercased()
+                let itemIdMatch = lowercaseFile.contains(itemIdLower)
+                let nameMatch = lowercaseFile.contains(itemNameLower)
+                let isDownloadFile = lowercaseFile.hasSuffix(".download") || 
+                                    lowercaseFile.hasSuffix(".pkg") || 
+                                    lowercaseFile.hasSuffix(".dmg")
+                
+                return (itemIdMatch || nameMatch) && isDownloadFile
+            }
+            
+            if hasMatchingFile {
+                return true
+            }
+        }
+        return false
+    }
+    
+    /// This works but might be a bit solved too complex - 
+    private func parseCommandLine(_ line: String) {
+        // Enhanced parsing to handle multiple command formats from AppInspector
+        writeLog("InspectState: Parsing command line: \(line)", logLevel: .debug)
+        
+        // Try to extract index from various command formats
+        var appIndex: Int?
+        var status: String?
+        var statusText: String?
+        
+        // Format 1: "listitem: index: X, status: Y, statustext: Z"
+        if let indexRange = line.range(of: "index: "),
+           let commaRange = line.range(of: ",", range: indexRange.upperBound..<line.endIndex) {
+            let indexStr = String(line[indexRange.upperBound..<commaRange.lowerBound])
+            appIndex = Int(indexStr)
+        }
+        
+        // Extract status
+        if let statusRange = line.range(of: "status: "),
+           let nextCommaRange = line.range(of: ",", range: statusRange.upperBound..<line.endIndex) {
+            status = String(line[statusRange.upperBound..<nextCommaRange.lowerBound])
+        } else if let statusRange = line.range(of: "status: ") {
+            status = String(line[statusRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        
+        // Extract status text
+        if let statusTextRange = line.range(of: "statustext: ") {
+            statusText = String(line[statusTextRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        
+        // Apply updates based on parsed information
+        guard let index = appIndex, index < items.count else {
+            writeLog("InspectState: Invalid or missing index in command: \(line)", logLevel: .debug)
+            return
+        }
+        
+        let app = items[index]
+        
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if let status = status {
+                switch status.lowercased() {
+                case "success":
+                    self.completedItems.insert(app.id)
+                    self.downloadingItems.remove(app.id)
+                    writeLog("InspectState: \(app.displayName) installation completed (from command)", logLevel: .info)
+                case "wait":
+                    self.downloadingItems.insert(app.id)
+                    writeLog("InspectState: \(app.displayName) downloading (from command)", logLevel: .info)
+                case "pending":
+                    self.downloadingItems.remove(app.id)
+                    self.completedItems.remove(app.id)
+                    writeLog("InspectState: \(app.displayName) pending (from command)", logLevel: .info)
+                default:
+                    writeLog("InspectState: Unknown status '\(status)' for \(app.displayName)", logLevel: .debug)
+                }
+            }
+            
+            // Also check for German status texts in case status field is missing
+            if let statusText = statusText {
+                if statusText.contains("Installed") || statusText.contains("Complete") || statusText.contains("erfolgreich") {
+                    self.completedItems.insert(app.id)
+                    self.downloadingItems.remove(app.id)
+                    writeLog("InspectState: \(app.displayName) installation completed (from status text)", logLevel: .info)
+                } else if statusText.contains("Downloading") || statusText.contains("Installing") || statusText.contains("heruntergeladen") {
+                    self.downloadingItems.insert(app.id)
+                    writeLog("InspectState: \(app.displayName) downloading (from status text)", logLevel: .info)
+                }
+            }
+        }
+    }
+    
+    private func startSideMessageRotation(interval: TimeInterval) {
+        // Stop existing timer if any
+        sideMessageTimer?.invalidate()
+        
+        // Start new timer
+        sideMessageTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            guard let self = self, self.uiConfiguration.sideMessages.count > 1 else { return }
+            
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.uiConfiguration.currentSideMessageIndex = (self.uiConfiguration.currentSideMessageIndex + 1) % self.uiConfiguration.sideMessages.count
+                writeLog("InspectState: Rotating to side message \(self.uiConfiguration.currentSideMessageIndex)", logLevel: .debug)
+            }
+        }
+        
+        writeLog("InspectState: Started side message rotation with interval \(interval)s", logLevel: .info)
+    }
+    
+    func getCurrentSideMessage() -> String? {
+        guard !uiConfiguration.sideMessages.isEmpty else { return nil }
+        let index = min(uiConfiguration.currentSideMessageIndex, uiConfiguration.sideMessages.count - 1)
+        return uiConfiguration.sideMessages[index]
+    }
+    
+    /// For best UX, especially in Enrollment scenarios - check if all apps are completed and update button state accordingly
+    func checkAndUpdateButtonState() {
+        let totalApps = items.count
+        let completedCount = completedItems.count
+        
+        writeLog("InspectState: Button state check - Total: \(totalApps), Completed: \(completedCount), AutoEnable: \(buttonConfiguration.autoEnableButton)", logLevel: .info)
+        
+        // If all apps are completed
+        if totalApps > 0 && completedCount == totalApps {
+            writeLog("InspectState: All apps completed (\(completedCount)/\(totalApps))", logLevel: .info)
+            
+            // Update button state directly since InspectView uses independent state management
+            DispatchQueue.main.asyncAfter(deadline: .now() + InspectConstants.debounceDelay) { [weak self] in
+                guard let self = self else { return }
+                if self.buttonConfiguration.autoEnableButton {
+                    self.buttonConfiguration.button1Text = "Continue"
+                    self.buttonConfiguration.button1Disabled = false
+                    writeLog("InspectState: Auto-enabling Continue button", logLevel: .info)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Unified Plist Validation
+
+    /// TODO: this can be build better, however plist are oftentime pretty complex, our actual at least works for the current use cases tested
+    
+    func validatePlistItem(_ item: InspectConfig.ItemConfig) -> Bool {
+        writeLog("InspectState: validatePlistItem called for '\(item.id)'", logLevel: .debug)
+        
+        // Use validation service for all validation logic
+        let request = ValidationRequest(
+            item: item,
+            plistSources: plistSources
+        )
+        
+        let result = validationService.validateItem(request)
+        
+        // Cache the result for UI consistency
+        plistValidationResults[item.id] = result.isValid
+        
+        // Log validation details for debugging
+        if let details = result.details {
+            writeLog("InspectState: Validation for '\(item.id)' - Path: \(details.path), Key: \(details.key ?? "N/A"), Expected: \(details.expectedValue ?? "N/A"), Actual: \(details.actualValue ?? "N/A"), Result: \(result.isValid)", logLevel: .debug)
+        } else {
+            writeLog("InspectState: Validation for '\(item.id)' - Type: \(result.validationType), Result: \(result.isValid)", logLevel: .debug)
+        }
+        
+        return result.isValid
+    }
+    
+    // MARK: - Validation Initialization
+    
+    /// Validate all items to populate the validation results dictionary
+    func validateAllItems() {
+        writeLog("InspectState: Validating all \(items.count) items", logLevel: .debug)
+        
+        for item in items {
+            let isValid = validatePlistItem(item)
+            writeLog("InspectState: Validated '\(item.id)': \(isValid)", logLevel: .debug)
+        }
+        
+        writeLog("InspectState: Validation complete. Results: \(plistValidationResults)", logLevel: .debug)
+    }
+    
+    
+    // NEW: Get actual plist value for display purposes
+    func getPlistValueForDisplay(item: InspectConfig.ItemConfig) -> String? {
+        guard let plistKey = item.plistKey else { return nil }
+        
+        // Use validation service to get the actual plist value
+        for path in item.paths {
+            if let value = validationService.getPlistValue(at: path, key: plistKey) {
+                return value
+            }
+        }
+        return nil
+    }
+    
+    
+    deinit {
+        writeLog("InspectState.deinit() - Starting resource cleanup", logLevel: .info)
+        
+        // Stop all timers
+        updateTimer?.invalidate()
+        updateTimer = nil
+        fileSystemCheckTimer?.invalidate() 
+        fileSystemCheckTimer = nil
+        sideMessageTimer?.invalidate()
+        sideMessageTimer = nil
+        
+        // Stop DispatchSource monitoring
+        commandFileMonitor?.cancel()
+        commandFileMonitor = nil
+        
+        // Stop FSEvents monitoring and clear delegate to prevent any potential retain cycles
+        fsEventsMonitor.stopMonitoring()
+        fsEventsMonitor.delegate = nil
+        
+        // Cancel all debounced operations
+        debouncedUpdater.cancelAll()
+        
+        // Clear AppInspector reference
+        appInspector = nil
+        
+        // Note: Services (validationService, configurationService) are value types with no explicit cleanup needed
+        // They will be automatically deallocated when InspectState is deallocated
+        
+        writeLog("InspectState.deinit() - Resource cleanup completed", logLevel: .info)
+    }
+    
+    // MARK: - Helper Functions
+    
+}

--- a/dialog/Views/Inspect/InspectValidationService.swift
+++ b/dialog/Views/Inspect/InspectValidationService.swift
@@ -1,0 +1,386 @@
+//
+//  InspectValidationService.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 25/07/2025
+//  Business logic service for plist and file validation
+//
+
+import Foundation
+
+// MARK: - Validation Models
+
+struct ValidationRequest {
+    let item: InspectConfig.ItemConfig
+    let plistSources: [InspectConfig.PlistSourceConfig]?
+}
+
+struct ValidationResult {
+    let itemId: String
+    let isValid: Bool
+    let validationType: ValidationType
+    let details: ValidationDetails?
+}
+
+enum ValidationType {
+    case fileExistence
+    case plistValidation
+    case complexPlistValidation
+}
+
+struct ValidationDetails {
+    let path: String
+    let key: String?
+    let expectedValue: String?
+    let actualValue: String?
+    let evaluationType: String?
+}
+
+// MARK: - Validation Service
+
+class InspectValidationService {
+    
+    // MARK: - Public API
+    
+    /// Main validation entry point - determines validation type and delegates
+    func validateItem(_ request: ValidationRequest) -> ValidationResult {
+        let item = request.item
+        
+        // Check for simplified plist validation first
+        if item.plistKey != nil {
+            return validateSimplePlistItem(item)
+        }
+        
+        // Check for complex plist sources validation
+        if let plistSources = request.plistSources {
+            for source in plistSources {
+                if item.paths.contains(source.path) {
+                    return validateComplexPlistItem(item, source: source)
+                }
+            }
+        }
+        
+        // Fallback to file existence validation
+        return validateFileExistence(item)
+    }
+    
+    /// Get actual plist value for display purposes
+    func getPlistValue(at path: String, key: String) -> String? {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = FileManager.default.contents(atPath: path),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            return nil
+        }
+        
+        // Support nested keys with dot notation
+        let keyParts = key.components(separatedBy: ".")
+        var current: Any = plist
+        
+        for keyPart in keyParts {
+            if let dict = current as? [String: Any] {
+                current = dict[keyPart] ?? NSNull()
+            } else if let array = current as? [Any], let index = Int(keyPart), index < array.count {
+                current = array[index]
+            } else {
+                return nil // Key doesn't exist
+            }
+            
+            if current is NSNull {
+                return nil // Key doesn't exist
+            }
+        }
+        
+        // Convert value to string for display
+        return formatValueForDisplay(current)
+    }
+    
+    // MARK: - Private Validation Methods
+    
+    private func validateFileExistence(_ item: InspectConfig.ItemConfig) -> ValidationResult {
+        // Debug logging to understand what's happening
+        writeLog("ValidationService: Checking file existence for '\(item.id)'", logLevel: .debug)
+        
+        var foundPath: String? = nil
+        let exists = item.paths.first { path in
+            let fileExists = FileManager.default.fileExists(atPath: path)
+            writeLog("ValidationService: Path '\(path)' exists: \(fileExists)", logLevel: .debug)
+            if fileExists {
+                foundPath = path
+            }
+            return fileExists
+        } != nil
+        
+        writeLog("ValidationService: File existence result for '\(item.id)': \(exists)", logLevel: .debug)
+        
+        return ValidationResult(
+            itemId: item.id,
+            isValid: exists,
+            validationType: .fileExistence,
+            details: foundPath != nil ? ValidationDetails(
+                path: foundPath!,
+                key: nil,
+                expectedValue: "File exists",
+                actualValue: exists ? "Found" : "Not found",
+                evaluationType: "file_existence"
+            ) : nil
+        )
+    }
+    
+    private func validateSimplePlistItem(_ item: InspectConfig.ItemConfig) -> ValidationResult {
+        guard let plistKey = item.plistKey else {
+            return ValidationResult(itemId: item.id, isValid: false, validationType: .plistValidation, details: nil)
+        }
+        
+        for path in item.paths {
+            if let result = checkSimplePlistKey(at: path, key: plistKey, expectedValue: item.expectedValue, evaluation: item.evaluation) {
+                let actualValue = getPlistValue(at: path, key: plistKey)
+                let details = ValidationDetails(
+                    path: path,
+                    key: plistKey,
+                    expectedValue: item.expectedValue,
+                    actualValue: actualValue,
+                    evaluationType: item.evaluation
+                )
+                
+                return ValidationResult(
+                    itemId: item.id,
+                    isValid: result,
+                    validationType: .plistValidation,
+                    details: details
+                )
+            }
+        }
+        
+        // If we reach here, file doesn't exist or key not found - this is a failure
+        return ValidationResult(
+            itemId: item.id,
+            isValid: false,
+            validationType: .plistValidation,
+            details: ValidationDetails(
+                path: item.paths.first ?? "",
+                key: plistKey,
+                expectedValue: item.expectedValue,
+                actualValue: nil,
+                evaluationType: item.evaluation
+            )
+        )
+    }
+    
+    private func validateComplexPlistItem(_ item: InspectConfig.ItemConfig, source: InspectConfig.PlistSourceConfig) -> ValidationResult {
+        guard FileManager.default.fileExists(atPath: source.path),
+              let data = FileManager.default.contents(atPath: source.path),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            return ValidationResult(itemId: item.id, isValid: false, validationType: .complexPlistValidation, details: nil)
+        }
+        
+        // General validation using critical keys
+        if let criticalKeys = source.criticalKeys {
+            for key in criticalKeys {
+                if !checkNestedKey(key, in: plist, expectedValues: source.successValues) {
+                    return ValidationResult(itemId: item.id, isValid: false, validationType: .complexPlistValidation, details: nil)
+                }
+            }
+        }
+        
+        return ValidationResult(itemId: item.id, isValid: true, validationType: .complexPlistValidation, details: nil)
+    }
+    
+    // MARK: - Smart Evaluation System
+    
+    private func checkSimplePlistKey(at path: String, key: String, expectedValue: String?, evaluation: String? = nil) -> Bool? {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = FileManager.default.contents(atPath: path),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            return nil // File doesn't exist or can't be read
+        }
+        
+        // Support nested keys with dot notation (e.g., "Sets.0.ProxyAutoConfigURLString")
+        let keyParts = key.components(separatedBy: ".")
+        var current: Any = plist
+        
+        for keyPart in keyParts {
+            if let dict = current as? [String: Any] {
+                current = dict[keyPart] ?? NSNull()
+            } else if let array = current as? [Any], let index = Int(keyPart), index < array.count {
+                current = array[index]
+            } else {
+                writeLog("ValidationService: Key part '\(keyPart)' not found in path '\(key)'", logLevel: .info)
+                return false // Key doesn't exist
+            }
+            
+            if current is NSNull {
+                writeLog("ValidationService: Key '\(key)' is NSNull", logLevel: .info)
+                return false // Key doesn't exist
+            }
+        }
+        
+        // Smart evaluation system
+        let evaluationType = evaluation ?? "equals" // Default to equals for backward compatibility
+        
+        return performSmartEvaluation(
+            value: current,
+            evaluationType: evaluationType,
+            expectedValue: expectedValue,
+            key: key
+        )
+    }
+    
+    private func performSmartEvaluation(value: Any, evaluationType: String, expectedValue: String?, key: String) -> Bool {
+        switch evaluationType.lowercased() {
+        case "exists":
+            // Just check if key exists (ignore expectedValue)
+            let result = !(value is NSNull)
+            writeLog("ValidationService: Key '\(key)', Evaluation 'exists', Result: \(result)", logLevel: .info)
+            return result
+            
+        case "boolean":
+            // Smart boolean evaluation: 1, true, YES = true; 0, false, NO = false
+            guard let expectedValue = expectedValue else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'boolean' requires expectedValue", logLevel: .error)
+                return false
+            }
+            
+            let expectedBool = parseSmartBoolean(expectedValue)
+            let actualBool = parseSmartBoolean(value)
+            let result = actualBool == expectedBool
+            writeLog("ValidationService: Key '\(key)', Expected bool '\(expectedBool)', Actual bool '\(actualBool)', Result: \(result)", logLevel: .info)
+            return result
+            
+        case "contains":
+            // For arrays, check if contains the expectedValue
+            guard let expectedValue = expectedValue else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'contains' requires expectedValue", logLevel: .error)
+                return false
+            }
+            
+            if let arrayValue = value as? [Any] {
+                let result = arrayValue.contains { item in
+                    if let stringItem = item as? String {
+                        return stringItem == expectedValue
+                    }
+                    return String(describing: item) == expectedValue
+                }
+                writeLog("ValidationService: Key '\(key)', Array contains '\(expectedValue)', Result: \(result)", logLevel: .info)
+                return result
+            } else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'contains' requires array value", logLevel: .error)
+                return false
+            }
+            
+        case "range":
+            // For numbers, expectedValue like "1-100" checks range
+            guard let expectedValue = expectedValue, expectedValue.contains("-") else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'range' requires format 'min-max'", logLevel: .error)
+                return false
+            }
+            
+            let rangeParts = expectedValue.components(separatedBy: "-")
+            guard rangeParts.count == 2,
+                  let minValue = Double(rangeParts[0]),
+                  let maxValue = Double(rangeParts[1]) else {
+                writeLog("ValidationService: Key '\(key)', Invalid range format '\(expectedValue)'", logLevel: .error)
+                return false
+            }
+            
+            let actualNumber: Double
+            if let intVal = value as? Int {
+                actualNumber = Double(intVal)
+            } else if let doubleVal = value as? Double {
+                actualNumber = doubleVal
+            } else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'range' requires numeric value", logLevel: .error)
+                return false
+            }
+            
+            let result = actualNumber >= minValue && actualNumber <= maxValue
+            writeLog("ValidationService: Key '\(key)', Value \(actualNumber) in range \(minValue)-\(maxValue), Result: \(result)", logLevel: .info)
+            return result
+            
+        default: // "equals" and any other unknown types
+            // Default: exact string comparison (backward compatible)
+            guard let expectedValue = expectedValue else {
+                writeLog("ValidationService: Key '\(key)', Evaluation 'equals' requires expectedValue", logLevel: .error)
+                return false
+            }
+            
+            let result: Bool
+            if let stringValue = value as? String {
+                result = stringValue == expectedValue
+            } else if let boolValue = value as? Bool {
+                result = String(boolValue) == expectedValue
+            } else if let intValue = value as? Int {
+                result = String(intValue) == expectedValue
+            } else if let doubleValue = value as? Double {
+                result = String(doubleValue) == expectedValue
+            } else {
+                result = String(describing: value) == expectedValue
+            }
+            
+            writeLog("ValidationService: Key '\(key)', Expected '\(expectedValue)', Actual '\(String(describing: value))', Result: \(result)", logLevel: .info)
+            return result
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func parseSmartBoolean(_ value: Any) -> Bool {
+        if let boolValue = value as? Bool {
+            return boolValue
+        } else if let stringValue = value as? String {
+            let lower = stringValue.lowercased()
+            return lower == "true" || lower == "yes" || lower == "1"
+        } else if let intValue = value as? Int {
+            return intValue == 1
+        } else if let doubleValue = value as? Double {
+            return doubleValue == 1.0
+        }
+        return false
+    }
+    
+    private func formatValueForDisplay(_ value: Any) -> String {
+        if let stringValue = value as? String {
+            return stringValue
+        } else if let boolValue = value as? Bool {
+            return String(boolValue)
+        } else if let intValue = value as? Int {
+            return String(intValue)
+        } else if let doubleValue = value as? Double {
+            return String(doubleValue)
+        } else if let arrayValue = value as? [Any] {
+            return "[\(arrayValue.count) items]"
+        } else if let dictValue = value as? [String: Any] {
+            return "{\(dictValue.keys.count) keys}"
+        }
+        
+        return String(describing: value)
+    }
+    
+    private func checkNestedKey(_ keyPath: String, in dict: [String: Any], expectedValues: [String]?) -> Bool {
+        let components = keyPath.split(separator: ".")
+        var current: Any = dict
+        
+        for component in components {
+            if component == "*" {
+                // Handle wildcard - would need more complex logic
+                return true
+            }
+            
+            guard let currentDict = current as? [String: Any],
+                  let nextValue = currentDict[String(component)] else {
+                return false
+            }
+            current = nextValue
+        }
+        
+        // Check if value matches expected
+        if let expectedValues = expectedValues {
+            if let stringValue = current as? String {
+                return expectedValues.contains(stringValue)
+            } else if let intValue = current as? Int {
+                return expectedValues.contains(String(intValue))
+            }
+        }
+        
+        return true
+    }
+}

--- a/dialog/Views/Inspect/InspectView.swift
+++ b/dialog/Views/Inspect/InspectView.swift
@@ -1,0 +1,800 @@
+//
+//  InspectView.swift
+//  Dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//
+
+import SwiftUI
+import IOKit
+
+struct InspectView: View {
+    @StateObject private var inspectState = InspectState()
+    @State private var showingAboutPopover = false
+    
+    var body: some View {
+        Group {
+            switch inspectState.loadingState {
+            case .loading:
+                LoadingView()
+                    .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading state - showing LoadingView") } }
+                
+            case .failed(let errorMessage):
+                ConfigErrorView(
+                    errorMessage: errorMessage,
+                    onRetry: {
+                        inspectState.retryConfiguration()
+                    },
+                    onUseDefault: {
+                        inspectState.retryConfiguration()
+                    }
+                )
+                .onAppear { print("ERROR: InspectView: Failed state - showing ConfigErrorView: \(errorMessage)") }
+                
+            case .loaded:
+                switch inspectState.uiConfiguration.preset {
+                case "preset1":
+                    Preset1Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset1Layout") } }
+                case "preset2":
+                    Preset2Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset2Layout") } }
+                case "preset3":
+                    Preset3Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset3Layout") } }
+                case "preset4":
+                    Preset4Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset4Layout") } }
+                case "preset5":
+                    Preset5Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset5Layout") } }
+                case "preset1-mini":
+                    Preset1Layout(inspectState: inspectState, isMini: true)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset1Layout (mini)") } }
+                case "preset2-mini":
+                    Preset2Layout(inspectState: inspectState, isMini: true)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset2Layout (mini)") } }
+                case "preset3-mini":
+                    Preset3Layout(inspectState: inspectState, isMini: true)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset3Layout (mini)") } }
+                case "preset4-mini":
+                    Preset4Layout(inspectState: inspectState, isMini: true)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset4Layout (mini)") } }
+                case "preset5-mini":
+                    Preset5Layout(inspectState: inspectState, isMini: true)
+                        .onAppear { if appvars.debugMode { print("DEBUG: InspectView: Loading Preset5Layout (mini)") } }
+                default:
+                    Preset1Layout(inspectState: inspectState, isMini: false)
+                        .onAppear { print("ERROR: InspectView: Unknown preset '\(inspectState.uiConfiguration.preset)', loading default Preset1Layout") }
+                }
+            }
+        }
+        .onAppear {
+            if appvars.debugMode { print("DEBUG: InspectView: onAppear called, preset=\(inspectState.uiConfiguration.preset)") }
+            writeLog("InspectView: Starting memory-safe initialization", logLevel: .info)
+            inspectState.initialize()
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func getVisibleItems() -> [InspectConfig.ItemConfig] {
+        let totalItems = inspectState.items.count
+        guard totalItems > 0 else { return [] }
+        
+        if totalItems <= 5 {
+            return inspectState.items
+        }
+        
+        let completedCount = inspectState.completedItems.count
+        
+        if completedCount == 0 {
+            return Array(inspectState.items.prefix(5))
+        } else if completedCount >= totalItems - 5 {
+            return Array(inspectState.items.suffix(5))
+        } else {
+            let startIndex = max(0, completedCount - 2)
+            let endIndex = min(totalItems, startIndex + 5)
+            return Array(inspectState.items[startIndex..<endIndex])
+        }
+    }
+    
+    private func getSortedItemsByStatus() -> [InspectConfig.ItemConfig] {
+        let completed = inspectState.items.filter { inspectState.completedItems.contains($0.id) }
+        let installing = inspectState.items.filter { inspectState.downloadingItems.contains($0.id) }
+        let waiting = inspectState.items.filter { 
+            !inspectState.completedItems.contains($0.id) && !inspectState.downloadingItems.contains($0.id)
+        }
+        
+        if inspectState.uiConfiguration.preset == "preset3" && installing.isEmpty && !waiting.isEmpty {
+            let recentCompleted = Array(completed.reversed().prefix(2))
+            return recentCompleted + waiting
+        }
+        
+        let recentCompleted = completed.reversed()
+        return Array(recentCompleted) + installing + waiting
+    }
+    
+ 
+    private func shouldShowGroupSeparator(for item: InspectConfig.ItemConfig, in sortedItems: [InspectConfig.ItemConfig]) -> Bool {
+        guard let index = sortedItems.firstIndex(where: { $0.id == item.id }), index > 0 else { return false }
+        
+        let previousItem = sortedItems[index - 1]
+        let currentStatus = getItemStatusType(for: item)
+        let previousStatus = getItemStatusType(for: previousItem)
+        
+        return currentStatus != previousStatus
+    }
+    
+    /// Get item status type for grouping
+    private func getItemStatusType(for item: InspectConfig.ItemConfig) -> Int {
+        if inspectState.completedItems.contains(item.id) { return 0 }
+        if inspectState.downloadingItems.contains(item.id) { return 1 }
+        return 2
+    }
+    
+    /// Get status header text for preset2
+    private func getStatusHeaderText(for statusType: Int) -> String {
+        switch statusType {
+        case 0: return "Installed"
+        case 1: return "Currently Installing"
+        case 2: return "Pending Installation"
+        default: return ""
+        }
+    }
+    
+    /// Get item status text
+    private func getItemStatus(for item: InspectConfig.ItemConfig) -> String {
+        if inspectState.completedItems.contains(item.id) {
+            return "Installation Complete"
+        } else if inspectState.downloadingItems.contains(item.id) {
+            return "Downloading"
+        } else {
+            return "Pending"
+        }
+    }
+}
+
+/// Enhanced Installation Information popover using swiftDialog's built-in variables
+struct InstallationInfoPopoverView: View {
+    @ObservedObject var inspectState: InspectState
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 16) {
+            // Computer Model Header with Icon
+            VStack(spacing: 8) {
+                // Computer Icon (using actual device-specific icon like dialog --icon computer)
+                Image(nsImage: NSImage(named: NSImage.computerName) ?? NSImage())
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 64, height: 64)
+
+                if inspectState.config?.hideSystemDetails != true {
+                    // Computer Model
+                    Text(getSystemInfo("computermodel"))
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+
+                    // Serial Number
+                    Text(getSystemInfo("serialnumber"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .textSelection(.enabled)
+                } else {
+                    // Generic system info when details are hidden
+                    Text("System Information Hidden")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                }
+
+                // OS Name + Version (always shown as it's less sensitive)
+                Text("\(getSystemInfo("osname")) \(getSystemInfo("osversion"))")
+                    .font(.subheadline)
+                    .foregroundColor(.primary)
+            }
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // User Information
+            VStack(alignment: .center, spacing: 4) {
+                if inspectState.config?.hideSystemDetails != true {
+                    // Full Name
+                    Text(getSystemInfo("userfullname"))
+                        .font(.headline)
+                        .fontWeight(.semibold)
+
+                    // Username
+                    Text(getSystemInfo("username"))
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                } else {
+                    // Generic user info when details are hidden
+                    Text("User Details Hidden")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // Progress Overview
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Progress Overview")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(spacing: 6) {
+                    EnhancedInfoRow(label: "Total Items", value: "\(inspectState.items.count)")
+                    EnhancedInfoRow(label: "Completed", value: "\(inspectState.completedItems.count)",
+                                  valueColor: inspectState.completedItems.count > 0 ? .green : .primary)
+                    EnhancedInfoRow(label: "Installing", value: "\(inspectState.downloadingItems.count)",
+                                  valueColor: inspectState.downloadingItems.count > 0 ? .blue : .primary)
+                    EnhancedInfoRow(label: "Pending", value: "\(inspectState.items.count - inspectState.completedItems.count - inspectState.downloadingItems.count)",
+                                  valueColor: .secondary)
+
+                    let progress = inspectState.items.isEmpty ? 0.0 : Double(inspectState.completedItems.count) / Double(inspectState.items.count)
+                    EnhancedInfoRow(label: "Progress", value: "\(Int(progress * 100))%",
+                                  valueColor: progress == 1.0 ? .green : .blue)
+                }
+            }
+
+            // Current Activity (if any items are installing)
+            if !inspectState.downloadingItems.isEmpty {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Currently Installing")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    ForEach(inspectState.items.filter { inspectState.downloadingItems.contains($0.id) }, id: \.id) { item in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(Color.blue)
+                                .frame(width: 6, height: 6)
+                            Text(item.displayName)
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 340)
+        .frame(maxHeight: 500)
+    }
+
+    /// Get system information using swiftDialog's built-in variables
+    private func getSystemInfo(_ key: String) -> String {
+        let systemInfo = getEnvironmentVars()
+        return systemInfo[key] ?? "Unknown"
+    }
+}
+
+/// Enhanced info row component with better styling and color support
+struct EnhancedInfoRow: View {
+    let label: String
+    let value: String
+    let valueColor: Color
+
+    init(label: String, value: String, valueColor: Color = .primary) {
+        self.label = label
+        self.value = value
+        self.valueColor = valueColor
+    }
+
+    var body: some View {
+        HStack {
+            Text(label + ":")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(width: 90, alignment: .leading)
+
+            Spacer()
+
+            Text(value)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(valueColor)
+                .textSelection(.enabled)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Legacy info row component for backward compatibility
+struct InfoRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        EnhancedInfoRow(label: label, value: value)
+    }
+}
+
+/// Placeholder card for empty slots in the 5-card display
+struct PlaceholderCardView: View {
+    let scale: CGFloat
+    
+    var body: some View {
+        VStack(spacing: 8 * scale) {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.gray.opacity(0.1))
+                .frame(width: 64 * scale, height: 64 * scale)
+            
+            Text("")
+                .font(.caption)
+                .frame(height: 32 * scale)
+            
+            Text("")
+                .font(.caption2)
+        }
+        .frame(width: 100 * scale, height: 120 * scale)
+        .padding(12 * scale)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.clear)
+        )
+    }
+}
+
+/// Individual item card component for preset3 Setup Manager style
+struct ItemCardView: View {
+    let item: InspectConfig.ItemConfig
+    let isCompleted: Bool
+    let isDownloading: Bool
+    let highlightColor: String
+    let scale: CGFloat
+    
+    var body: some View {
+        VStack(spacing: 8 * scale) {
+            // Item icon with status overlay
+            ZStack {
+                // Item icon
+                if let iconPath = item.icon,
+                   FileManager.default.fileExists(atPath: iconPath) {
+                    Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 64 * scale, height: 64 * scale)
+                        .cornerRadius(12)
+                } else {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.blue.opacity(0.1))
+                        .frame(width: 64 * scale, height: 64 * scale)
+                        .overlay(
+                            Image(systemName: "app.fill")
+                                .font(.system(size: 32 * scale))
+                                .foregroundColor(.blue)
+                        )
+                }
+                
+                // Status indicator overlay
+                VStack {
+                    HStack {
+                        Spacer()
+                        if isCompleted {
+                            Circle()
+                                .fill(Color.green)
+                                .frame(width: 20 * scale, height: 20 * scale)
+                                .overlay(
+                                    Image(systemName: "checkmark")
+                                        .font(.system(size: 12, weight: .bold))
+                                        .foregroundColor(.white)
+                                )
+                        } else if isDownloading {
+                            Circle()
+                                .fill(Color.white)
+                                .frame(width: 20 * scale, height: 20 * scale)
+                                .overlay(
+                                    ProgressView()
+                                        .scaleEffect(0.6)
+                                )
+                        }
+                    }
+                    Spacer()
+                }
+                .frame(width: 64 * scale, height: 64 * scale)
+            }
+            
+            // Item name
+            Text(item.displayName)
+                .font(.caption)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .frame(height: 32 * scale)
+            
+            // Status text
+            if isDownloading {
+                Text("Installing...")
+                    .font(.caption2)
+                    .foregroundColor(.blue)
+            } else if isCompleted {
+                Text("Installed")
+                    .font(.caption2)
+                    .foregroundColor(.green)
+            } else {
+                Text("Waiting...")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(width: 100 * scale, height: 120 * scale)
+        .padding(12 * scale)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(NSColor.controlBackgroundColor))
+                .opacity(isDownloading ? 1.0 : 0.5)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isDownloading ? Color(hex: highlightColor) : Color.clear, lineWidth: 2)
+        )
+        .scaleEffect(isDownloading ? 1.05 : 1.0)
+        .animation(.easeInOut(duration: InspectConstants.scaleAnimationDuration), value: isDownloading)
+    }
+}
+
+/// Configuration structure matching the JSON format
+struct InspectConfig: Codable {
+    let title: String?
+    let message: String?
+    let infobox: String?
+    let icon: String?
+    let iconsize: Int?
+    let width: Int?
+    let height: Int?
+    let scanInterval: Int?
+    let cachePaths: [String]?
+    let sideMessage: [String]?
+    let sideInterval: Int?
+    let style: String?
+    let liststyle: String?
+    let preset: String?
+    let popupButton: String?
+    let highlightColor: String?
+    let backgroundColor: String?
+    let backgroundImage: String?
+    let backgroundOpacity: Double?
+    let textOverlayColor: String?
+    let gradientColors: [String]?
+    let button1Text: String?
+    let button1Disabled: Bool?
+    let button2Text: String?
+    let button2Disabled: Bool?
+    let button2Visible: Bool?
+    let buttonStyle: String?
+    let autoEnableButton: Bool?
+    let hideSystemDetails: Bool?
+    let colorThresholds: ColorThresholds?   // Configurable color thresholds for visualizations
+    let plistSources: [PlistSourceConfig]?  // Array of plist configurations to monitor for preset5
+    let items: [ItemConfig]
+    
+    struct ItemConfig: Codable {
+        let id: String
+        let displayName: String
+        let guiIndex: Int
+        let paths: [String]
+        let icon: String?
+        let plistKey: String?           // Optional plist key to check
+        let expectedValue: String?      // Optional expected value for the key
+        let evaluation: String?         // NEW: Optional evaluation type (equals, boolean, exists, contains, range)
+        let category: String?           // NEW: Optional custom category name
+        let categoryIcon: String?       // NEW: Optional custom category icon
+    }
+    
+    struct PlistSourceConfig: Codable {
+        let path: String                    // Path to plist file
+        let type: String                    // "compliance", "health", "licenses", "preferences", "custom"
+        let displayName: String             // Human-readable name
+        let icon: String?                   // SF Symbol icon name
+        let keyMappings: [KeyMapping]?      // How to interpret plist keys
+        let successValues: [String]?        // Values that indicate "success" (for booleans: ["true"])
+        let criticalKeys: [String]?         // Keys that are considered critical
+        let categoryPrefix: [String: String]? // Map prefixes to category names
+    }
+    
+    struct KeyMapping: Codable {
+        let key: String                     // Original plist key
+        let displayName: String?            // Human-readable name (optional)
+        let category: String?               // Override category (optional)
+        let isCritical: Bool?              // Override critical status (optional)
+    }
+    
+    // Generic color threshold system for all presets
+    struct ColorThresholds: Codable {
+        let excellent: Double              // Default: 90%+ = Green
+        let good: Double                   // Default: 70%+ = Blue  
+        let warning: Double                // Default: 50%+ = Orange
+        // Below warning = Red
+        
+        // Configurable labels for different use cases
+        let excellentLabel: String?        // e.g., "Excellent", "Secure", "Complete"
+        let goodLabel: String?             // e.g., "Good", "Safe", "In Progress"
+        let warningLabel: String?          // e.g., "Warning", "At Risk", "Needs Attention"
+        let criticalLabel: String?         // e.g., "Critical", "Unsafe", "Failed"
+        
+        // Configurable colors (hex strings)
+        let excellentColor: String?        // Custom color for excellent range
+        let goodColor: String?             // Custom color for good range
+        let warningColor: String?          // Custom color for warning range
+        let criticalColor: String?         // Custom color for critical range
+        
+        static let `default` = ColorThresholds(
+            excellent: 0.9, good: 0.7, warning: 0.5,
+            excellentLabel: nil, goodLabel: nil, warningLabel: nil, criticalLabel: nil,
+            excellentColor: nil, goodColor: nil, warningColor: nil, criticalColor: nil
+        )
+        
+        func getColor(for score: Double) -> Color {
+            if score >= excellent {
+                return excellentColor != nil ? Color(hex: excellentColor!) : .green
+            } else if score >= good {
+                return goodColor != nil ? Color(hex: goodColor!) : .blue
+            } else if score >= warning {
+                return warningColor != nil ? Color(hex: warningColor!) : .orange
+            } else {
+                return criticalColor != nil ? Color(hex: criticalColor!) : .red
+            }
+        }
+        
+        func getLabel(for score: Double) -> String {
+            if score >= excellent {
+                return excellentLabel ?? "Excellent"
+            } else if score >= good {
+                return goodLabel ?? "Good"
+            } else if score >= warning {
+                return warningLabel ?? "Warning"
+            } else {
+                return criticalLabel ?? "Critical"
+            }
+        }
+        
+        func getStatusIcon(for score: Double) -> String {
+            if score >= excellent {
+                return "checkmark.circle.fill"
+            } else if score >= good {
+                return "checkmark.circle"
+            } else if score >= warning {
+                return "exclamationmark.triangle.fill"
+            } else {
+                return "x.circle.fill"
+            }
+        }
+        
+        // Utility method for progress text
+        func getProgressText(passed: Int, total: Int) -> String {
+            let score = total > 0 ? Double(passed) / Double(total) : 0.0
+            let percentage = Int(score * 100)
+            return "\(passed)/\(total) (\(percentage)%)"
+        }
+        
+        // Utility method for status badges
+        func getStatusBadge(for score: Double) -> (color: Color, label: String, icon: String) {
+            return (
+                color: getColor(for: score),
+                label: getLabel(for: score),
+                icon: getStatusIcon(for: score)
+            )
+        }
+        
+        // NEW: Helper methods for flexible positive/negative color theming
+        func getPositiveColor() -> Color {
+            return excellentColor != nil ? Color(hex: excellentColor!) : .green
+        }
+        
+        func getNegativeColor() -> Color {
+            return criticalColor != nil ? Color(hex: criticalColor!) : .red
+        }
+        
+        func getValidationColor(isValid: Bool) -> Color {
+            return isValid ? getPositiveColor() : getNegativeColor()
+        }
+    }
+    
+    // Custom decoder to handle missing items field
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        message = try container.decodeIfPresent(String.self, forKey: .message)
+        infobox = try container.decodeIfPresent(String.self, forKey: .infobox)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        iconsize = try container.decodeIfPresent(Int.self, forKey: .iconsize)
+        width = try container.decodeIfPresent(Int.self, forKey: .width)
+        height = try container.decodeIfPresent(Int.self, forKey: .height)
+        scanInterval = try container.decodeIfPresent(Int.self, forKey: .scanInterval)
+        cachePaths = try container.decodeIfPresent([String].self, forKey: .cachePaths)
+        sideMessage = try container.decodeIfPresent([String].self, forKey: .sideMessage)
+        sideInterval = try container.decodeIfPresent(Int.self, forKey: .sideInterval)
+        style = try container.decodeIfPresent(String.self, forKey: .style)
+        liststyle = try container.decodeIfPresent(String.self, forKey: .liststyle)
+        preset = try container.decodeIfPresent(String.self, forKey: .preset)
+        popupButton = try container.decodeIfPresent(String.self, forKey: .popupButton)
+        highlightColor = try container.decodeIfPresent(String.self, forKey: .highlightColor)
+        backgroundColor = try container.decodeIfPresent(String.self, forKey: .backgroundColor)
+        backgroundImage = try container.decodeIfPresent(String.self, forKey: .backgroundImage)
+        backgroundOpacity = try container.decodeIfPresent(Double.self, forKey: .backgroundOpacity)
+        textOverlayColor = try container.decodeIfPresent(String.self, forKey: .textOverlayColor)
+        gradientColors = try container.decodeIfPresent([String].self, forKey: .gradientColors)
+        button1Text = try container.decodeIfPresent(String.self, forKey: .button1Text)
+        button1Disabled = try container.decodeIfPresent(Bool.self, forKey: .button1Disabled)
+        button2Text = try container.decodeIfPresent(String.self, forKey: .button2Text)
+        button2Disabled = try container.decodeIfPresent(Bool.self, forKey: .button2Disabled)
+        button2Visible = try container.decodeIfPresent(Bool.self, forKey: .button2Visible)
+        buttonStyle = try container.decodeIfPresent(String.self, forKey: .buttonStyle)
+        autoEnableButton = try container.decodeIfPresent(Bool.self, forKey: .autoEnableButton)
+        hideSystemDetails = try container.decodeIfPresent(Bool.self, forKey: .hideSystemDetails)
+        colorThresholds = try container.decodeIfPresent(ColorThresholds.self, forKey: .colorThresholds)
+        plistSources = try container.decodeIfPresent([PlistSourceConfig].self, forKey: .plistSources)
+        
+        // Default to empty array if items not provided
+        items = try container.decodeIfPresent([ItemConfig].self, forKey: .items) ?? []
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case title, message, infobox, icon, iconsize, width, height, scanInterval, cachePaths
+        case sideMessage, sideInterval, style, liststyle, preset, popupButton
+        case highlightColor, backgroundColor, backgroundImage, backgroundOpacity
+        case textOverlayColor, gradientColors, button1Text, button1Disabled
+        case button2Text, button2Disabled, button2Visible, buttonStyle
+        case autoEnableButton, hideSystemDetails, colorThresholds, plistSources, items
+    }
+}
+
+// Color extension to support hex color parsing
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 128, 128, 128) // Default gray fallback
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}
+
+// MARK: - Loading and Error State Views
+
+struct LoadingView: View {
+    let scale: CGFloat
+    
+    init(scale: CGFloat = 1.0) {
+        self.scale = scale
+    }
+    
+    var body: some View {
+        VStack(spacing: 24 * scale) {
+            Spacer()
+            
+            // SwiftDialog Icon/Logo Area
+            VStack(spacing: 16 * scale) {
+                Image(systemName: "gear.circle.fill")
+                    .font(.system(size: 64 * scale))
+                    .foregroundColor(.blue)
+                
+                Text("swiftDialog")
+                    .font(.system(size: 24 * scale, weight: .semibold))
+                    .foregroundColor(.primary)
+            }
+            
+            // Loading Content
+            VStack(spacing: 16 * scale) {
+                ProgressView()
+                    .scaleEffect(1.2 * scale)
+                    .foregroundColor(.blue)
+                
+                Text("Loading Configuration...")
+                    .font(.system(size: 18 * scale, weight: .medium))
+                    .foregroundColor(.primary)
+                
+                Text("Please wait while the configuration is loaded")
+                    .font(.system(size: 14 * scale))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+struct ConfigErrorView: View {
+    let errorMessage: String
+    let onRetry: () -> Void
+    let onUseDefault: () -> Void
+    let scale: CGFloat
+    
+    init(errorMessage: String, onRetry: @escaping () -> Void, onUseDefault: @escaping () -> Void, scale: CGFloat = 1.0) {
+        self.errorMessage = errorMessage
+        self.onRetry = onRetry
+        self.onUseDefault = onUseDefault
+        self.scale = scale
+    }
+    
+    var body: some View {
+        VStack(spacing: 24 * scale) {
+            Spacer()
+            
+            // Error Icon and Title
+            VStack(spacing: 16 * scale) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 64 * scale))
+                    .foregroundColor(.orange)
+                
+                Text("Configuration Load Failed")
+                    .font(.system(size: 24 * scale, weight: .semibold))
+                    .foregroundColor(.primary)
+            }
+            
+            // Error Details
+            VStack(spacing: 12 * scale) {
+                Text("Unable to load the inspect configuration:")
+                    .font(.system(size: 16 * scale))
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                
+                Text(errorMessage)
+                    .font(.system(size: 14 * scale, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 20 * scale)
+                    .padding(.vertical, 8 * scale)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8 * scale)
+                            .fill(Color.gray.opacity(0.1))
+                    )
+                    .multilineTextAlignment(.center)
+            }
+            
+            // Action Buttons
+            VStack(spacing: 12 * scale) {
+                Button("Retry Loading") {
+                    onRetry()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                
+                Button("Use Test Configuration") {
+                    onUseDefault()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .padding(.top, 8 * scale)
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}

--- a/dialog/Views/Inspect/Preset1Layout.swift
+++ b/dialog/Views/Inspect/Preset1Layout.swift
@@ -1,0 +1,179 @@
+//
+//  Preset1Layout.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//  Traditional dialog presentation layout with icon and progress bar on left, app list on right
+
+import SwiftUI
+
+
+struct Preset1Layout: View, InspectLayoutProtocol {
+    @ObservedObject var inspectState: InspectState
+    let isMini: Bool
+    @State private var showingAboutPopover = false
+    
+    init(inspectState: InspectState, isMini: Bool = false) {
+        self.inspectState = inspectState
+        self.isMini = isMini
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            // Left sidebar with icon/image
+            VStack {
+                if let iconPath = inspectState.uiConfiguration.iconPath,
+                   FileManager.default.fileExists(atPath: iconPath) {
+                    Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 300 * scaleFactor, maxHeight: 300 * scaleFactor)
+                } else {
+                    // Default icon
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(Color.blue)
+                        .frame(width: 250 * scaleFactor, height: 250 * scaleFactor)
+                        .overlay(
+                            Image(systemName: "apps.iphone.badge.plus")
+                                .font(.system(size: 80 * scaleFactor))
+                                .foregroundColor(.white)
+                        )
+                }
+                
+                // Progress bar
+                if !inspectState.items.isEmpty {
+                    let progress = Double(inspectState.completedItems.count) / Double(inspectState.items.count)
+                    ProgressView(value: progress)
+                        .progressViewStyle(LinearProgressViewStyle())
+                        .frame(width: 200 * scaleFactor)
+                        .padding(.top, 20 * scaleFactor)
+                    
+                    Text("\(inspectState.completedItems.count) of \(inspectState.items.count) installed")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.top, 5 * scaleFactor)
+                }
+                
+                Spacer()
+                
+                // Install info button
+                Button(inspectState.uiConfiguration.popupButtonText) {
+                    showingAboutPopover.toggle()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.blue)
+                .font(.body)
+                .padding(.bottom, 20 * scaleFactor)
+                .popover(isPresented: $showingAboutPopover, arrowEdge: .top) {
+                    InstallationInfoPopoverView(inspectState: inspectState)
+                }
+            }
+            .frame(width: 320 * scaleFactor)
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            
+            // Right content area
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack {
+                    Text(inspectState.uiConfiguration.windowTitle)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                    Spacer()
+                    
+                    buttonArea()
+                }
+                .padding()
+                
+                if let currentMessage = inspectState.getCurrentSideMessage() {
+                    Text(currentMessage)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
+                        .padding(.bottom)
+                        .animation(.easeInOut(duration: InspectConstants.standardAnimationDuration), value: inspectState.uiConfiguration.currentSideMessageIndex)
+                }
+                
+                Divider()
+                
+                // Item list
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        let sortedItems = getSortedItemsByStatus()
+                        ForEach(sortedItems, id: \.id) { item in
+                            // Add group separator if needed
+                            if shouldShowGroupSeparator(for: item, in: sortedItems) {
+                                HStack {
+                                    Text(getStatusHeaderText(for: getItemStatusType(for: item)))
+                                        .font(.caption)
+                                        .fontWeight(.semibold)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                }
+                                .padding(.vertical, 8)
+                                .padding(.horizontal)
+                                .background(Color(NSColor.windowBackgroundColor))
+                            }
+                            HStack {
+                                // Item icon
+                                itemIcon(for: item, size: 32)
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.displayName)
+                                        .font(.system(size: 14, weight: .medium))
+                                    if !inspectState.completedItems.contains(item.id) {
+                                        Text(getItemStatus(for: item))
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                
+                                Spacer()
+                                
+                                // Status indicator
+                                statusIndicator(for: item)
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 12)
+                            
+                            if item.id != sortedItems.last?.id {
+                                Divider()
+                                    .padding(.leading, 60)
+                            }
+                        }
+                    }
+                    .padding(.vertical)
+                }
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func shouldShowGroupSeparator(for item: InspectConfig.ItemConfig, in sortedItems: [InspectConfig.ItemConfig]) -> Bool {
+        guard let currentIndex = sortedItems.firstIndex(where: { $0.id == item.id }) else { return false }
+        
+        if currentIndex == 0 { return true }
+        
+        let previousItem = sortedItems[currentIndex - 1]
+        let currentStatus = getItemStatusType(for: item)
+        let previousStatus = getItemStatusType(for: previousItem)
+        
+        return currentStatus != previousStatus
+    }
+    
+    private func getStatusHeaderText(for statusType: ItemStatusType) -> String {
+        switch statusType {
+        case .completed:
+            return "Completed"
+        case .downloading:
+            return "Installing"
+        case .pending:
+            return "Waiting"
+        }
+    }
+}

--- a/dialog/Views/Inspect/Preset2Layout.swift
+++ b/dialog/Views/Inspect/Preset2Layout.swift
@@ -1,0 +1,323 @@
+//
+//  Preset2Layout.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//  Card-based display and navigation
+//
+
+import SwiftUI
+
+struct Preset2Layout: View, InspectLayoutProtocol {
+    @ObservedObject var inspectState: InspectState
+    let isMini: Bool
+    @State private var showingAboutPopover = false
+    
+    init(inspectState: InspectState, isMini: Bool = false) {
+        self.inspectState = inspectState
+        self.isMini = isMini
+    }
+    
+    var body: some View {
+        let scale: CGFloat = isMini ? 0.75 : 1.0
+        
+        VStack(spacing: 0) {
+            // Top section with welcome and large icon
+            VStack(spacing: 20 * scale) {
+                // Main icon - larger for Setup Manager style
+                if let iconPath = inspectState.uiConfiguration.iconPath,
+                   FileManager.default.fileExists(atPath: iconPath) {
+                    Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 100 * scale)
+                        .cornerRadius(15)
+                } else {
+                    // Default Setup Manager style icon
+                    RoundedRectangle(cornerRadius: 15)
+                        .fill(
+                            LinearGradient(
+                                gradient: Gradient(colors: [Color.blue.opacity(0.8), Color.blue]),
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 120 * scale, height: 120 * scale)
+                        .overlay(
+                            Image(systemName: "briefcase.fill")
+                                .font(.system(size: 40 * scale))
+                                .foregroundColor(.white)
+                        )
+                }
+                
+                // Welcome title
+                Text(inspectState.uiConfiguration.windowTitle)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                
+                if let currentMessage = inspectState.getCurrentSideMessage() {
+                    Text(currentMessage)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40 * scale)
+                        .animation(.easeInOut(duration: InspectConstants.standardAnimationDuration), value: inspectState.uiConfiguration.currentSideMessageIndex)
+                }
+            }
+            .padding(.top, 40 * scale)
+            .padding(.bottom, 30 * scale)
+            
+            // App cards with navigation arrows
+            VStack(spacing: 8 * scale) {
+                HStack(spacing: 20 * scale) {
+                    // Left arrow
+                    Button(action: {
+                        scrollLeft()
+                    }) {
+                        Image(systemName: "chevron.left.circle.fill")
+                            .font(.system(size: 32 * scale))
+                            .foregroundColor(canScrollLeft() ? Color(hex: inspectState.uiConfiguration.highlightColor) : .gray.opacity(0.3))
+                    }
+                    .disabled(!canScrollLeft())
+                    .buttonStyle(PlainButtonStyle())
+                    
+                    // App cards - show 5 at a time
+                    HStack(spacing: 16 * scale) {
+                        ForEach(getVisibleItemsWithOffset(), id: \.id) { app in
+                            ItemCardView(item: app, 
+                                      isCompleted: inspectState.completedItems.contains(app.id),
+                                      isDownloading: inspectState.downloadingItems.contains(app.id),
+                                      highlightColor: inspectState.uiConfiguration.highlightColor,
+                                      scale: scale)
+                        }
+                        
+                        // Fill remaining slots with placeholder cards if needed
+                        ForEach(0..<max(0, 5 - getVisibleItemsWithOffset().count), id: \.self) { _ in
+                            PlaceholderCardView(scale: scale)
+                        }
+                    }
+                    .animation(.easeInOut(duration: InspectConstants.standardAnimationDuration), value: inspectState.scrollOffset)
+                    .animation(.easeInOut(duration: InspectConstants.longAnimationDuration), value: inspectState.completedItems.count)
+                    .animation(.easeInOut(duration: InspectConstants.longAnimationDuration), value: inspectState.downloadingItems.count)
+                    .onChange(of: inspectState.completedItems.count) { _ in
+                        smartAutoScroll()
+                    }
+                    .onChange(of: inspectState.downloadingItems.count) { _ in
+                        smartAutoScroll()
+                    }
+                    
+                    // Right arrow
+                    Button(action: {
+                        scrollRight()
+                    }) {
+                        Image(systemName: "chevron.right.circle.fill")
+                            .font(.system(size: 32 * scale))
+                            .foregroundColor(canScrollRight() ? Color(hex: inspectState.uiConfiguration.highlightColor) : .gray.opacity(0.3))
+                    }
+                    .disabled(!canScrollRight())
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .padding(.horizontal, 40 * scale)
+            }
+            
+            Spacer()
+            
+            // Bottom progress section
+            VStack(spacing: 12) {
+                if !inspectState.items.isEmpty {
+                    let progress = Double(inspectState.completedItems.count) / Double(inspectState.items.count)
+                    
+                    // Current item being processed
+                    if let currentItem = inspectState.items.first(where: { inspectState.downloadingItems.contains($0.id) }) {
+                        Text(currentItem.displayName)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Text("Step \(inspectState.completedItems.count + 1) of \(inspectState.items.count)")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    } else if inspectState.completedItems.count == inspectState.items.count && !inspectState.items.isEmpty {
+                        Text("Installation Complete")
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Text("All applications installed successfully")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    // Progress bar
+                    ProgressView(value: progress)
+                        .progressViewStyle(LinearProgressViewStyle())
+                        .frame(height: 6)
+                        .padding(.horizontal, 80 * scale)
+                }
+                
+                // Action buttons - Reserve space to prevent progress bar jumping
+                HStack(spacing: 20 * scale) {
+                    Button(inspectState.uiConfiguration.popupButtonText) {
+                        showingAboutPopover.toggle()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.blue)
+                    .font(.body)
+                    .popover(isPresented: $showingAboutPopover, arrowEdge: .top) {
+                        InstallationInfoPopoverView(inspectState: inspectState)
+                    }
+                    
+                    Spacer()
+                    
+                    // Always reserve space for buttons to prevent layout jumping
+                    HStack(spacing: 12) {
+                        // Button 2 (Secondary/Cancel) - Exit code 2
+                        if inspectState.buttonConfiguration.button2Visible && !inspectState.buttonConfiguration.button2Text.isEmpty {
+                            Button(inspectState.buttonConfiguration.button2Text) {
+                                writeLog("Preset2Layout: User clicked button2 (\(inspectState.buttonConfiguration.button2Text)) - exiting with code 2", logLevel: .info)
+                                exit(2)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.large)
+                            .disabled(inspectState.buttonConfiguration.button2Disabled)
+                            .opacity(inspectState.completedItems.count == inspectState.items.count ? 1.0 : 0.0)
+                        }
+                        
+                        // Button 1 (Primary) - Exit code 0 - Always present to reserve space
+                        Button(inspectState.buttonConfiguration.button1Text) {
+                            writeLog("Preset2Layout: User clicked button1 (\(inspectState.buttonConfiguration.button1Text)) - exiting with code 0", logLevel: .info)
+                            exit(0)
+                        }
+                        .keyboardShortcut(.defaultAction)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .disabled(inspectState.buttonConfiguration.button1Disabled)
+                        .opacity(inspectState.completedItems.count == inspectState.items.count ? 1.0 : 0.0)
+                    }
+                }
+                .padding(.horizontal, 40 * scale)
+            }
+            .padding(.bottom, 30 * scale)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+    
+    // MARK: - Private Helper Methods
+    
+    /// Get visible items with manual scroll offset for preset2 (Setup Manager style after swap)
+    /// Ordered: Installed → Installing → Pending
+    private func getVisibleItemsWithOffset() -> [InspectConfig.ItemConfig] {
+        let totalItems = inspectState.items.count
+        guard totalItems > 0 else { return [] }
+        
+        // Separate into three categories: installed, installing, pending
+        let completedItems = inspectState.items.filter { inspectState.completedItems.contains($0.id) }
+        let downloadingItems = inspectState.items.filter { inspectState.downloadingItems.contains($0.id) }
+        let pendingItems = inspectState.items.filter { 
+            !inspectState.completedItems.contains($0.id) && !inspectState.downloadingItems.contains($0.id)
+        }
+        
+        // Combine: completed first, then downloading, then pending
+        let sortedItems = completedItems + downloadingItems + pendingItems
+        
+        if sortedItems.count <= 5 {
+            // If 5 or fewer items total, show them all
+            return sortedItems
+        }
+        
+        // Use manual scroll offset on the sorted list
+        let startIndex = max(0, min(inspectState.scrollOffset, sortedItems.count - 5))
+        let endIndex = min(sortedItems.count, startIndex + 5)
+        return Array(sortedItems[startIndex..<endIndex])
+    }
+    
+    /// Check if we can scroll left (show earlier apps)
+    private func canScrollLeft() -> Bool {
+        return inspectState.scrollOffset > 0
+    }
+    
+    /// Check if we can scroll right (show later items)
+    private func canScrollRight() -> Bool {
+        let totalItems = inspectState.items.count
+        return inspectState.scrollOffset < max(0, totalItems - 5)
+    }
+    
+    /// Get total items in sorted order (completed + pending)
+    private func getSortedItemsCount() -> Int {
+        return inspectState.items.count
+    }
+    
+    /// Scroll left by one item
+    private func scrollLeft() {
+        if canScrollLeft() {
+            inspectState.scrollOffset = max(0, inspectState.scrollOffset - 1)
+            // Disable auto-scroll for 5 seconds after manual scroll
+            inspectState.lastManualScrollTime = Date()
+        }
+    }
+    
+    /// Scroll right by one item
+    private func scrollRight() {
+        if canScrollRight() {
+            let totalItems = getSortedItemsCount()
+            inspectState.scrollOffset = min(max(0, totalItems - 5), inspectState.scrollOffset + 1)
+            // Disable auto-scroll for 5 seconds after manual scroll
+            inspectState.lastManualScrollTime = Date()
+        }
+    }
+    
+    /// Smart auto-scrolling to keep active installations in view
+    private func smartAutoScroll() {
+        // Only auto-scroll if we're in preset2 (Setup Manager style after swap)
+        guard inspectState.uiConfiguration.preset == "preset2" else { return }
+        
+        // Don't auto-scroll if user manually scrolled in the last 5 seconds
+        if let lastManualScroll = inspectState.lastManualScrollTime,
+           Date().timeIntervalSince(lastManualScroll) < InspectConstants.manualScrollTimeoutInterval {
+            return
+        }
+        
+        let totalItems = inspectState.items.count
+        guard totalItems > 5 else { return } // No scrolling needed if 5 or fewer items
+        
+        // Get sorted items in order: Installed → Installing → Pending
+        let completedItems = inspectState.items.filter { inspectState.completedItems.contains($0.id) }
+        let downloadingItems = inspectState.items.filter { inspectState.downloadingItems.contains($0.id) }
+        let pendingItems = inspectState.items.filter { 
+            !inspectState.completedItems.contains($0.id) && !inspectState.downloadingItems.contains($0.id)
+        }
+        
+        let sortedItems = completedItems + downloadingItems + pendingItems
+        
+        // Find the optimal view window
+        if !downloadingItems.isEmpty {
+            // Priority 1: If items are installing, center them in view
+            let firstDownloadingIndex = sortedItems.firstIndex(where: { inspectState.downloadingItems.contains($0.id) }) ?? 0
+            let lastDownloadingIndex = sortedItems.lastIndex(where: { inspectState.downloadingItems.contains($0.id) }) ?? 0
+            
+            // Calculate the center position for downloading items
+            let downloadingCenter = (firstDownloadingIndex + lastDownloadingIndex) / 2
+            
+            // Try to center the downloading items in the 5-card view
+            var targetOffset = downloadingCenter - 2 // Center in a 5-card view
+            
+            // Adjust if multiple downloads span more than 5 cards
+            if lastDownloadingIndex - firstDownloadingIndex >= 5 {
+                // Show the first 5 downloading items
+                targetOffset = firstDownloadingIndex
+            }
+            
+            // Ensure we don't scroll past bounds
+            targetOffset = max(0, min(targetOffset, totalItems - 5))
+            inspectState.scrollOffset = targetOffset
+            
+        } else if completedItems.count > 0 && pendingItems.count > 0 {
+            // Priority 2: Show boundary between completed and pending
+            // Show the last 2 completed and first 3 pending
+            let targetOffset = max(0, completedItems.count - 2)
+            inspectState.scrollOffset = min(targetOffset, totalItems - 5)
+            
+        } else if pendingItems.count > 0 {
+            // Priority 3: If only pending items remain, show the first ones
+            inspectState.scrollOffset = completedItems.count
+        }
+        // If all items are completed, stay at current position
+    }
+}

--- a/dialog/Views/Inspect/Preset3Layout.swift
+++ b/dialog/Views/Inspect/Preset3Layout.swift
@@ -1,0 +1,312 @@
+//
+//  Preset3Layout.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 19/07/2025
+//  Compact list style layout with progress bar at bottom
+//
+
+import SwiftUI
+
+struct Preset3Layout: View, InspectLayoutProtocol {
+    @ObservedObject var inspectState: InspectState
+    let isMini: Bool
+    
+    init(inspectState: InspectState, isMini: Bool = false) {
+        self.inspectState = inspectState
+        self.isMini = isMini
+    }
+    
+    var body: some View {
+        let scale: CGFloat = isMini ? 0.75 : 1.0
+        let textColor = getTextColor()
+        
+        ZStack {
+            // Custom background (gradient, image, or color)
+            customBackground()
+            
+            VStack(spacing: 0) {
+                // Fixed header with title and button - always visible
+                HStack {
+                    Text(inspectState.uiConfiguration.windowTitle)
+                        .font(.title)
+                        .fontWeight(.semibold)
+                        .foregroundColor(textColor)
+                    Spacer()
+                    
+                    HStack(spacing: 12) {
+                        // Button 2 (Secondary/Cancel) - Exit code 2
+                        // Only show when all items are completed (like preset3)
+                        if inspectState.completedItems.count == inspectState.items.count && 
+                           inspectState.buttonConfiguration.button2Visible && !inspectState.buttonConfiguration.button2Text.isEmpty {
+                            Button(inspectState.buttonConfiguration.button2Text) {
+                                writeLog("Preset3Layout: User clicked button2 (\(inspectState.buttonConfiguration.button2Text)) - exiting with code 2", logLevel: .info)
+                                exit(2)
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(inspectState.buttonConfiguration.button2Disabled)
+                        }
+                        
+                        // Button 1 (Primary) - Exit code 0
+                        Button(inspectState.buttonConfiguration.button1Text) {
+                            writeLog("Preset3Layout: User clicked button1 (\(inspectState.buttonConfiguration.button1Text)) - exiting with code 0", logLevel: .info)
+                            exit(0)
+                        }
+                        .keyboardShortcut(.defaultAction)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(inspectState.buttonConfiguration.button1Disabled)
+                    }
+                }
+                .padding()
+                .background(Color.black.opacity(0.1))
+                
+                // Enlarged company icon section - always visible
+                VStack(spacing: 12) {
+                    if let iconPath = inspectState.uiConfiguration.iconPath,
+                       FileManager.default.fileExists(atPath: iconPath),
+                       let nsImage = NSImage(contentsOfFile: iconPath) {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 120 * scale)
+                            .cornerRadius(12)
+                    } else {
+                        // Use a more visible company logo placeholder
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(Color.white.opacity(0.2))
+                                .frame(width: 140 * scale, height: 120 * scale)
+                            
+                            VStack(spacing: 8) {
+                                Image(systemName: "building.2.fill")
+                                    .font(.system(size: 36 * scale))
+                                    .foregroundColor(.white)
+                                Text("ACME")
+                                    .font(.title3)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.white)
+                            }
+                        }
+                    }
+                    
+                    // Add subtitle message if available
+                    if let subtitle = inspectState.uiConfiguration.subtitleMessage {
+                        Text(subtitle)
+                            .font(.headline)
+                            .foregroundColor(textColor)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 20) // Increased padding for better proportion
+                
+                if let currentMessage = inspectState.getCurrentSideMessage() {
+                    Text(currentMessage)
+                        .font(.body)
+                        .foregroundColor(textColor.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 16) // Add vertical breathing room
+                        .animation(.easeInOut(duration: InspectConstants.standardAnimationDuration), value: inspectState.uiConfiguration.currentSideMessageIndex)
+                }
+                
+                // Scrollable app list with auto-scrolling
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: true) {
+                        LazyVStack(spacing: 8) {
+                            let sortedItems = getSortedItemsByStatus() // Use simple order: Latest Completed → Installing → Waiting
+                            ForEach(sortedItems, id: \.id) { item in
+                                HStack {
+                                    // Small item icon
+                                    if let iconPath = item.icon,
+                                       FileManager.default.fileExists(atPath: iconPath) {
+                                        Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 24 * scale, height: 24 * scale)
+                                    } else {
+                                        Image(systemName: "app.fill")
+                                            .font(.system(size: 20 * scale))
+                                            .foregroundColor(.blue)
+                                            .frame(width: 24 * scale, height: 24 * scale)
+                                    }
+                                    
+                                    // Item name
+                                    Text(item.displayName)
+                                        .font(.body)
+                                        .foregroundColor(textColor)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    
+                                    // Status indicator
+                                    if inspectState.completedItems.contains(item.id) {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundColor(.green)
+                                            .font(.title3)
+                                    } else if inspectState.downloadingItems.contains(item.id) {
+                                        HStack(spacing: 8) { // More spacing between spinner and text
+                                            ProgressView()
+                                                .scaleEffect(0.6) // Much smaller spinner
+                                                .frame(width: 12, height: 12) // Smaller fixed size
+                                            Text("Installing...")
+                                                .font(.caption)
+                                                .foregroundColor(textColor.opacity(0.7))
+                                        }
+                                    } else {
+                                        Text("Pending")
+                                            .font(.caption)
+                                            .foregroundColor(textColor.opacity(0.7))
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 2)
+                                            .background(Color.white.opacity(0.2))
+                                            .cornerRadius(4)
+                                    }
+                                }
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 12)
+                                .background(Color.black.opacity(0.1))
+                                .cornerRadius(6)
+                            }
+                        }
+                        .padding(.horizontal)
+                        .padding(.bottom)
+                        .onChange(of: inspectState.completedItems.count) { _ in
+                            // Auto-scroll to top when new item completes
+                            let sortedItems = getSortedItemsByStatus()
+                            if let firstItem = sortedItems.first {
+                                withAnimation(.easeInOut(duration: InspectConstants.longAnimationDuration)) {
+                                    proxy.scrollTo(firstItem.id, anchor: .top)
+                                }
+                            }
+                            
+                            // Auto-enable button when all items are completed
+                            inspectState.checkAndUpdateButtonState()
+                        }
+                        .onChange(of: inspectState.downloadingItems.count) { _ in
+                            // Auto-scroll when installing status changes
+                            let sortedItems = getSortedItemsByStatus()
+                            if let firstInstalling = sortedItems.first(where: { inspectState.downloadingItems.contains($0.id) }) {
+                                withAnimation(.easeInOut(duration: InspectConstants.longAnimationDuration)) {
+                                    proxy.scrollTo(firstInstalling.id, anchor: .center)
+                                }
+                            }
+                            
+                            // Check button state when downloading status changes
+                            inspectState.checkAndUpdateButtonState()
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+                
+                // Progress bar section - moved to bottom as requested
+                if !inspectState.items.isEmpty {
+                    let progress = Double(inspectState.completedItems.count) / Double(inspectState.items.count)
+                    let isComplete = inspectState.completedItems.count == inspectState.items.count
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text(isComplete ? "Installation Complete!" : "Installation Progress")
+                                .font(.headline)
+                                .foregroundColor(textColor)
+                            Spacer()
+                            if isComplete {
+                                Text("All installations completed successfully")
+                                    .font(.subheadline)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(textColor)
+                            } else {
+                                Text("\(inspectState.completedItems.count) of \(inspectState.items.count) completed")
+                                    .font(.subheadline)
+                                    .foregroundColor(textColor.opacity(0.8))
+                            }
+                        }
+                        
+                        ProgressView(value: progress)
+                            .progressViewStyle(LinearProgressViewStyle())
+                            .scaleEffect(y: 2.0)
+                    }
+                    .padding()
+                    .background(Color.black.opacity(0.1))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+                    .padding(.bottom, 12) // Bottom spacing
+                }
+            }
+        }
+    }
+    
+    // MARK: - Private Helper Methods
+    
+    @ViewBuilder
+    private func customBackground() -> some View {
+        if !inspectState.backgroundConfiguration.gradientColors.isEmpty && inspectState.backgroundConfiguration.gradientColors.count >= 2 {
+            // Gradient background
+            LinearGradient(
+                gradient: Gradient(colors: inspectState.backgroundConfiguration.gradientColors.compactMap { Color(hex: $0) }),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        } else if let backgroundImage = inspectState.backgroundConfiguration.backgroundImage,
+                  FileManager.default.fileExists(atPath: backgroundImage),
+                  let nsImage = NSImage(contentsOfFile: backgroundImage) {
+            // Background image with proper frame constraints
+            GeometryReader { geometry in
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .clipped()
+                    .opacity(inspectState.backgroundConfiguration.backgroundOpacity)
+            }
+        } else if let backgroundColor = inspectState.backgroundConfiguration.backgroundColor {
+            // Solid color background
+            Color(hex: backgroundColor)
+        } else {
+            // Default background
+            Color(NSColor.windowBackgroundColor)
+        }
+    }
+    
+    private func getTextColor() -> Color {
+        if let textColor = inspectState.backgroundConfiguration.textOverlayColor {
+            return Color(hex: textColor)
+        }
+        
+        // Auto-contrast logic - if we have dark background, use light text
+        if !inspectState.backgroundConfiguration.gradientColors.isEmpty || inspectState.backgroundConfiguration.backgroundImage != nil {
+            return .white
+        } else if let bgColor = inspectState.backgroundConfiguration.backgroundColor {
+            // Simple heuristic: if color contains dark values, use white text
+            if bgColor.lowercased().contains("dark") || bgColor == "#000000" {
+                return .white
+            }
+        }
+        
+        return Color.primary // Default system color
+    }
+    
+    private func getSortedItemsByStatus() -> [InspectConfig.ItemConfig] {
+        return inspectState.items.sorted { item1, item2 in
+            let status1 = getItemStatusPriority(item1)
+            let status2 = getItemStatusPriority(item2)
+            
+            if status1 != status2 {
+                return status1 < status2
+            }
+            
+            // Same status - maintain original GUI order
+            return item1.guiIndex < item2.guiIndex
+        }
+    }
+    
+    private func getItemStatusPriority(_ item: InspectConfig.ItemConfig) -> Int {
+        if inspectState.downloadingItems.contains(item.id) {
+            return 0 // Installing items first
+        } else if inspectState.completedItems.contains(item.id) {
+            return 1 // Completed items second
+        } else {
+            return 2 // Pending items last
+        }
+    }
+}

--- a/dialog/Views/Inspect/Preset4Layout.swift
+++ b/dialog/Views/Inspect/Preset4Layout.swift
@@ -1,0 +1,686 @@
+//
+//  Preset4Layout.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 22/07/2025
+//  Simple, high-contrast inspection layout for any type of file/folder/setting checks
+//  Use cases: Font installation, template files, compliance settings, app presence
+//
+
+import SwiftUI
+
+struct Preset4Layout: View, InspectLayoutProtocol {
+    @ObservedObject var inspectState: InspectState
+    var isMini: Bool
+    @State private var showingDetailPopover = false
+    @State private var selectedItem: InspectConfig.ItemConfig?
+    
+    // Use centralized validation results from InspectState - no local caching needed
+    
+    private var scaleFactor: CGFloat {
+        return isMini ? 0.75 : 1.0
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // Simple Header
+            headerSection
+            
+            // Main Content Area
+            GeometryReader { geometry in
+                ScrollView {
+                    VStack(spacing: 20 * scaleFactor) {
+                        // Compact Status Summary
+                        simpleStatusSummary
+                            .padding(.top, 5 * scaleFactor)
+                        
+                        // Clean Grid with improved layout
+                        simpleInspectionGrid(geometry: geometry)
+                        
+                        // Simple Buttons with proper spacing
+                        buttonArea()
+                            .padding(.top, 10 * scaleFactor)
+                    }
+                    .padding(.horizontal, 30 * scaleFactor)
+                    .padding(.vertical, 20 * scaleFactor)
+                }
+            }
+        }
+        .background(customBackground())
+        .onAppear {
+            // Validation results are now managed centrally by InspectState
+        }
+        .onChange(of: inspectState.items.count) { _ in
+            // Validation results are now managed centrally by InspectState
+        }
+    }
+    
+    // MARK: - Header Section
+    
+    private var headerSection: some View {
+        VStack(spacing: 8 * scaleFactor) {
+            HStack(spacing: 15 * scaleFactor) {
+                // Compact logo
+                if let iconPath = inspectState.uiConfiguration.iconPath,
+                   FileManager.default.fileExists(atPath: iconPath) {
+                    Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 40 * scaleFactor, height: 40 * scaleFactor)
+                }
+                
+                // Compact title only
+                Text(inspectState.uiConfiguration.windowTitle)
+                    .font(.title2.weight(.semibold))
+                    .foregroundColor(.primary)
+                
+                Spacer()
+            }
+            
+            // Message if available
+            if let message = inspectState.uiConfiguration.subtitleMessage, !message.isEmpty {
+                Text(message)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, 40 * scaleFactor)
+        .padding(.vertical, 15 * scaleFactor)
+        .background(.regularMaterial)
+        .overlay(
+            Rectangle()
+                .frame(height: 1)
+                .foregroundColor(.secondary.opacity(0.2)),
+            alignment: .bottom
+        )
+    }
+    
+    // MARK: - Status Summary
+    
+    private var simpleStatusSummary: some View {
+        let totalItems = inspectState.items.count
+        let presentItems = inspectState.plistValidationResults.values.filter { $0 }.count
+        let missingItems = totalItems - presentItems
+        let progress = totalItems == 0 ? 0.0 : Double(presentItems) / Double(totalItems)
+        
+        return HStack(spacing: 20 * scaleFactor) {
+            // Compact progress info
+            HStack(spacing: 12 * scaleFactor) {
+                Text("\(presentItems)/\(totalItems)")
+                    .font(.title3.weight(.bold))
+                    .foregroundColor(.primary)
+                
+                ProgressView(value: progress)
+                    .progressViewStyle(LinearProgressViewStyle(tint: inspectState.colorThresholds.getColor(for: progress)))
+                    .frame(width: 120 * scaleFactor, height: 6 * scaleFactor)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 3 * scaleFactor)
+                            .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                    )
+            }
+            
+            // Compact status counts
+            HStack(spacing: 15 * scaleFactor) {
+                CompactStatusCount(count: presentItems, label: inspectState.colorThresholds.getLabel(for: 1.0), color: inspectState.colorThresholds.getColor(for: 1.0), scaleFactor: scaleFactor)
+                CompactStatusCount(count: missingItems, label: inspectState.colorThresholds.getLabel(for: 0.0), color: inspectState.colorThresholds.getColor(for: 0.0), scaleFactor: scaleFactor)
+            }
+            
+            Spacer()
+            
+            // Inspection Details button
+            Button("Details...") {
+                showingDetailPopover = true
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundColor(.accentColor)
+            .popover(isPresented: $showingDetailPopover) {
+                InspectionDetailPopover(
+                    items: inspectState.items,
+                    validationResults: inspectState.plistValidationResults,
+                    downloadingItems: inspectState.downloadingItems,
+                    scaleFactor: scaleFactor,
+                    hideSystemDetails: inspectState.config?.hideSystemDetails ?? false,
+                    inspectState: inspectState
+                )
+            }
+        }
+        .padding(.horizontal, 20 * scaleFactor)
+        .padding(.vertical, 12 * scaleFactor)
+        .background(.thickMaterial)
+        .cornerRadius(8 * scaleFactor)
+    }
+    
+    // MARK: - Simple Grid
+    
+    private func simpleInspectionGrid(geometry: GeometryProxy) -> some View {
+        let columns = calculateColumns(for: geometry.size.width)
+        
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 18 * scaleFactor), count: columns), 
+                         spacing: 18 * scaleFactor) {
+            ForEach(inspectState.items, id: \.id) { item in
+                SimpleInspectionTile(
+                    title: item.displayName,
+                    icon: item.icon,
+                    isPresent: inspectState.plistValidationResults[item.id] ?? false,
+                    isChecking: inspectState.downloadingItems.contains(item.id),
+                    scaleFactor: scaleFactor,
+                    colorThresholds: inspectState.colorThresholds,
+                    item: item
+                )
+            }
+        }
+    }
+    
+    // MARK: - Helper Functions
+    
+    private func calculateColumns(for width: CGFloat) -> Int {
+        let minTileWidth: CGFloat = 220 * scaleFactor
+        let spacing: CGFloat = 18 * scaleFactor
+        let padding: CGFloat = 80 * scaleFactor // Total horizontal padding
+        
+        let availableWidth = width - padding
+        let maxColumns = Int((availableWidth + spacing) / (minTileWidth + spacing))
+        
+        return max(2, min(maxColumns, 5)) // 2-5 columns for better balance
+    }
+    
+    // MARK: - Background Customization
+    
+    @ViewBuilder
+    private func customBackground() -> some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Base background
+                Color(NSColor.controlBackgroundColor)
+                
+                // Custom background from config
+                if let config = inspectState.config {
+                    // Gradient background
+                    if let gradientColors = config.gradientColors, gradientColors.count >= 2 {
+                        LinearGradient(
+                            colors: gradientColors.compactMap { Color(hex: $0) },
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                        .opacity(config.backgroundOpacity ?? 1.0)
+                    }
+                    // Solid color background
+                    else if let backgroundColor = config.backgroundColor {
+                        Color(hex: backgroundColor)
+                            .opacity(config.backgroundOpacity ?? 1.0)
+                    }
+                    // Background image
+                    else if let backgroundImage = config.backgroundImage {
+                        if FileManager.default.fileExists(atPath: backgroundImage) {
+                            if let nsImage = NSImage(contentsOfFile: backgroundImage) {
+                                Image(nsImage: nsImage)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: geometry.size.width, height: geometry.size.height)
+                                    .clipped()
+                                    .opacity(config.backgroundOpacity ?? 1.0)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .ignoresSafeArea(.all)
+    }
+    
+    // MARK: - Button Area
+    
+    private func buttonArea() -> some View {
+        HStack(spacing: 12 * scaleFactor) {
+            Button("Continue") {
+                writeLog("Preset4Layout: User clicked Continue button - exiting with code 0", logLevel: .info)
+                exit(0)
+            }
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            
+            Button("Show Details") {
+                showingDetailPopover = true
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+    
+    // MARK: - Validation Results Caching
+    
+    
+    // MARK: - Plist Compliance Checking (Legacy - kept for reference)
+    
+    private func checkItemCompliance(item: InspectConfig.ItemConfig) -> Bool {
+        // Use unified validation service for all items
+        return inspectState.validatePlistItem(item)
+    }
+}
+
+// MARK: - Compact Status Count Component
+
+struct CompactStatusCount: View {
+    let count: Int
+    let label: String
+    let color: Color
+    let scaleFactor: CGFloat
+    
+    var body: some View {
+        HStack(spacing: 4 * scaleFactor) {
+            Circle()
+                .fill(color)
+                .frame(width: 6 * scaleFactor, height: 6 * scaleFactor)
+            
+            Text("\(count)")
+                .font(.caption.weight(.bold))
+                .foregroundColor(color)
+        }
+    }
+}
+
+// MARK: - Simple Inspection Tile (Horizontal Layout)
+
+struct SimpleInspectionTile: View {
+    let title: String
+    let icon: String?
+    let isPresent: Bool
+    let isChecking: Bool
+    let scaleFactor: CGFloat
+    let colorThresholds: InspectConfig.ColorThresholds
+    let item: InspectConfig.ItemConfig? // Add item context for plist validation
+    
+    var body: some View {
+        HStack(spacing: 15 * scaleFactor) {
+            // Item icon (from config)
+            Group {
+                if let iconPath = icon, FileManager.default.fileExists(atPath: iconPath) {
+                    Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    // Default system icons based on item type
+                    Image(systemName: getSystemIcon(for: title))
+                        .font(.title2)
+                        .foregroundColor(.accentColor)
+                }
+            }
+            .frame(width: 32 * scaleFactor, height: 32 * scaleFactor)
+            
+            // Content with status - fixed height container
+            VStack(alignment: .leading, spacing: 4 * scaleFactor) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+                    .frame(minHeight: 20 * scaleFactor, alignment: .top)
+                
+                // Status text instead of icon overlay
+                Text(getStatusText())
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(getStatusColor())
+                    .frame(minHeight: 14 * scaleFactor, alignment: .top)
+            }
+            .frame(minHeight: 40 * scaleFactor, alignment: .top)
+            
+            Spacer()
+            
+            // Status indicator (smaller, on the right)
+            Group {
+                if isChecking {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .frame(width: 16 * scaleFactor, height: 16 * scaleFactor)
+                } else if isPresent {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.body)
+                        .foregroundColor(colorThresholds.getColor(for: 1.0))
+                } else {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.body)
+                        .foregroundColor(colorThresholds.getColor(for: 0.0))
+                }
+            }
+            .frame(width: 20 * scaleFactor, height: 20 * scaleFactor)
+        }
+        .frame(minHeight: 72 * scaleFactor) // Fixed minimum height for all cards
+        .padding(.horizontal, 18 * scaleFactor)
+        .padding(.vertical, 16 * scaleFactor)
+        .background(Color.white)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8 * scaleFactor)
+                .stroke(isPresent ? colorThresholds.getColor(for: 1.0) : 
+                       isChecking ? Color.blue : 
+                       colorThresholds.getColor(for: 0.0), 
+                       lineWidth: 2)
+        )
+        .cornerRadius(8 * scaleFactor)
+        .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
+    }
+    
+    private func getSystemIcon(for title: String) -> String {
+        let lowercaseTitle = title.lowercased()
+        
+        // Font-related
+        if lowercaseTitle.contains("font") || lowercaseTitle.contains("arial") || lowercaseTitle.contains("helvetica") {
+            return "textformat"
+        }
+        // Template-related  
+        if lowercaseTitle.contains("template") || lowercaseTitle.contains("powerpoint") {
+            return "doc.richtext"
+        }
+        // Security-related
+        if lowercaseTitle.contains("security") || lowercaseTitle.contains("policy") {
+            return "shield.checkered"
+        }
+        // VPN-related
+        if lowercaseTitle.contains("vpn") || lowercaseTitle.contains("network") {
+            return "network"
+        }
+        // Antivirus-related
+        if lowercaseTitle.contains("antivirus") || lowercaseTitle.contains("virus") {
+            return "checkmark.shield"
+        }
+        // Backup-related
+        if lowercaseTitle.contains("backup") {
+            return "externaldrive"
+        }
+        // Certificate-related
+        if lowercaseTitle.contains("certificate") || lowercaseTitle.contains("keychain") {
+            return "key"
+        }
+        // Printer-related
+        if lowercaseTitle.contains("print") {
+            return "printer"
+        }
+        // Default
+        return "gear"
+    }
+    
+    private func getStatusText() -> String {
+        if isChecking {
+            return "Checking..."
+        } else if let item = item, item.plistKey != nil {
+            // For plist validation, use compliance terminology
+            return isPresent ? (colorThresholds.excellentLabel ?? "Compliant") : (colorThresholds.criticalLabel ?? "Non-Compliant")
+        } else {
+            // For file existence, use present/missing terminology
+            return isPresent ? "Present" : "Missing"
+        }
+    }
+    
+    private func getStatusColor() -> Color {
+        if isChecking {
+            return .blue
+        } else if isPresent {
+            return colorThresholds.getColor(for: 1.0)
+        } else {
+            return colorThresholds.getColor(for: 0.0)
+        }
+    }
+}
+
+// MARK: - Inspection Detail Popover
+
+struct InspectionDetailPopover: View {
+    let items: [InspectConfig.ItemConfig]
+    let validationResults: [String: Bool]
+    let downloadingItems: Set<String>
+    let scaleFactor: CGFloat
+    let hideSystemDetails: Bool
+    let inspectState: InspectState
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // Header
+            HStack {
+                Text("Inspection Details")
+                    .font(.title2.weight(.semibold))
+                    .foregroundColor(.primary)
+                Spacer()
+                Text("\(validationResults.values.filter { $0 }.count)/\(items.count) Present")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.secondary)
+            }
+            
+            Divider()
+            
+            // Scrollable list of items
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    ForEach(items, id: \.id) { item in
+                        InspectionDetailItem(
+                            item: item,
+                            isPresent: inspectState.plistValidationResults[item.id] ?? false,
+                            isChecking: downloadingItems.contains(item.id),
+                            scaleFactor: scaleFactor,
+                            hideSystemDetails: hideSystemDetails,
+                            inspectState: inspectState
+                        )
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .frame(maxHeight: 400)
+        }
+        .padding(20)
+        .frame(width: 500)
+    }
+}
+
+// MARK: - Individual Detail Item
+
+struct InspectionDetailItem: View {
+    let item: InspectConfig.ItemConfig
+    let isPresent: Bool
+    let isChecking: Bool
+    let scaleFactor: CGFloat
+    let hideSystemDetails: Bool
+    let inspectState: InspectState
+    @State private var showFullPaths = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Item header with status
+            HStack {
+                // Status indicator
+                Circle()
+                    .fill(isPresent ? inspectState.colorThresholds.getColor(for: 1.0) : isChecking ? Color.blue : inspectState.colorThresholds.getColor(for: 0.0))
+                    .frame(width: 8, height: 8)
+                
+                // Item name
+                Text(item.displayName)
+                    .font(.headline.weight(.medium))
+                    .foregroundColor(.primary)
+                
+                Spacer()
+                
+                // Status text
+                Text(getStatusText())
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(getStatusColor())
+            }
+            
+            // Paths section (conditionally shown)
+            if !hideSystemDetails {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Checked Paths:")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundColor(.secondary)
+                        
+                        Spacer()
+                        
+                        if item.paths.count > 1 {
+                            Button(showFullPaths ? "Show Less" : "Show All (\(item.paths.count))") {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    showFullPaths.toggle()
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .font(.caption)
+                            .foregroundColor(.accentColor)
+                        }
+                    }
+                    
+                    let pathsToShow = showFullPaths ? item.paths : Array(item.paths.prefix(1))
+                    
+                    ForEach(Array(pathsToShow.enumerated()), id: \.offset) { index, path in
+                        HStack(alignment: .top, spacing: 8) {
+                            // Path indicator
+                            Circle()
+                                .fill(Color.secondary.opacity(0.5))
+                                .frame(width: 4, height: 4)
+                                .padding(.top, 6)
+                            
+                            // Path text with word wrapping
+                            Text(path)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .lineLimit(showFullPaths ? nil : 2)
+                        }
+                    }
+                    
+                    if !showFullPaths && item.paths.count > 1 {
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(Color.secondary.opacity(0.3))
+                                .frame(width: 4, height: 4)
+                                .padding(.top, 6)
+                            
+                            Text("... and \(item.paths.count - 1) more path\(item.paths.count - 1 == 1 ? "" : "s")")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .italic()
+                        }
+                    }
+                }
+                .padding(.leading, 12)
+            } else {
+                // Show generic info when paths are hidden
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Path Details Hidden")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundColor(.secondary)
+                    
+                    Text("Checking \(item.paths.count) configured location\(item.paths.count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .italic()
+                }
+                .padding(.leading, 12)
+            }
+            
+            // NEW: Plist Key and Value Information (shown when plist validation is configured)
+            if let plistKey = item.plistKey {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Plist Validation:")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundColor(.secondary)
+                    
+                    // Plist key
+                    HStack(alignment: .top, spacing: 8) {
+                        Circle()
+                            .fill(Color.blue.opacity(0.5))
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 6)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Key:")
+                                .font(.caption.weight(.medium))
+                                .foregroundColor(.secondary)
+                            Text(plistKey)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.primary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    
+                    // Expected value (if configured)
+                    if let expectedValue = item.expectedValue {
+                        HStack(alignment: .top, spacing: 8) {
+                            Circle()
+                                .fill(Color.orange.opacity(0.5))
+                                .frame(width: 4, height: 4)
+                                .padding(.top, 6)
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Expected:")
+                                    .font(.caption.weight(.medium))
+                                    .foregroundColor(.secondary)
+                                Text(expectedValue)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.orange)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                    
+                    // Actual value (from plist)
+                    HStack(alignment: .top, spacing: 8) {
+                        Circle()
+                            .fill(inspectState.colorThresholds.getValidationColor(isValid: isPresent))
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 6)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Actual:")
+                                .font(.caption.weight(.medium))
+                                .foregroundColor(.secondary)
+                            
+                            if let actualValue = inspectState.getPlistValueForDisplay(item: item) {
+                                Text(actualValue)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(isPresent ? inspectState.colorThresholds.getColor(for: 1.0) : inspectState.colorThresholds.getColor(for: 0.0))
+                                    .textSelection(.enabled)
+                            } else {
+                                Text("Key not found or file missing")
+                                    .font(.caption)
+                                    .foregroundColor(inspectState.colorThresholds.getColor(for: 0.0))
+                                    .italic()
+                            }
+                        }
+                    }
+                }
+                .padding(.leading, 12)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isPresent ? inspectState.colorThresholds.getColor(for: 1.0).opacity(0.3) : 
+                       isChecking ? Color.blue.opacity(0.3) : 
+                       inspectState.colorThresholds.getColor(for: 0.0).opacity(0.3), 
+                       lineWidth: 1)
+        )
+    }
+    
+    private func getStatusText() -> String {
+        if isChecking {
+            return "Checking..."
+        } else if isPresent {
+            return "Present"
+        } else {
+            return "Missing"
+        }
+    }
+    
+    private func getStatusColor() -> Color {
+        if isChecking {
+            return .blue
+        } else if isPresent {
+            return inspectState.colorThresholds.getColor(for: 1.0)
+        } else {
+            return inspectState.colorThresholds.getColor(for: 0.0)
+        }
+    }
+}

--- a/dialog/Views/Inspect/Preset5Layout.swift
+++ b/dialog/Views/Inspect/Preset5Layout.swift
@@ -1,0 +1,1123 @@
+//
+//  Preset5Layout.swift
+//  dialog
+//
+//  Created by Henry Stamerjohann, Declarative IT GmbH, 22/07/2025
+//  Security Compliance Dashboard - Corporate style layout
+//
+
+import SwiftUI
+
+struct Preset5Layout: View, InspectLayoutProtocol {
+    @ObservedObject var inspectState: InspectState
+    let isMini: Bool
+    @State private var showingAboutPopover = false
+    @State private var complianceData: [ComplianceCategory] = []
+    @State private var lastCheck: String = ""
+    @State private var overallScore: Double = 0.0
+    @State private var criticalIssues: [ComplianceItem] = []
+    @State private var allFailingItems: [ComplianceItem] = []
+    
+    init(inspectState: InspectState, isMini: Bool = false) {
+        self.inspectState = inspectState
+        self.isMini = isMini
+    }
+    
+    var body: some View {
+        let scale: CGFloat = isMini ? 0.75 : 1.0
+        
+        VStack(spacing: 0) {
+            // Header Section - Corporate Style
+            VStack(spacing: 16 * scale) {
+                // Security Icon and Title
+                HStack(spacing: 12 * scale) {
+                    // Icon from configuration
+                    if let iconPath = inspectState.uiConfiguration.iconPath,
+                       FileManager.default.fileExists(atPath: iconPath) {
+                        Image(nsImage: NSImage(contentsOfFile: iconPath) ?? NSImage())
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 52 * scale, height: 52 * scale)
+                    } else {
+                        Image(systemName: "shield.checkered")
+                            .font(.system(size: 24 * scale, weight: .medium))
+                            .foregroundColor(.blue)
+                            .frame(width: 32 * scale, height: 32 * scale)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 2 * scale) {
+                        Text(inspectState.uiConfiguration.windowTitle)
+                            .font(.system(size: 20 * scale, weight: .semibold))
+                            .foregroundColor(.primary)
+                        
+                        if let message = inspectState.uiConfiguration.subtitleMessage, !message.isEmpty {
+                            Text(message)
+                                .font(.system(size: 14 * scale))
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("Last Check: \(lastCheck)")
+                                .font(.system(size: 12 * scale))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 32 * scale)
+                .padding(.top, 24 * scale)
+                
+                // Overall Progress Bar - Cleaner design
+                VStack(spacing: 8 * scale) {
+                    HStack {
+                        // Progress fraction - smaller text
+                        Text("\(Int(overallScore * Double(getTotalChecks())))/\(getTotalChecks())")
+                            .font(.system(size: 16 * scale, weight: .semibold, design: .monospaced))
+                            .foregroundColor(.primary)
+                        
+                        // Progress bar - thinner and more refined
+                        GeometryReader { geometry in
+                            ZStack(alignment: .leading) {
+                                // Background
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.15))
+                                    .frame(height: 4 * scale)
+                                    .cornerRadius(2 * scale)
+                                
+                                // Progress fill
+                                Rectangle()
+                                    .fill(inspectState.colorThresholds.getColor(for: overallScore))
+                                    .frame(width: geometry.size.width * overallScore, height: 4 * scale)
+                                    .cornerRadius(2 * scale)
+                            }
+                        }
+                        .frame(height: 4 * scale)
+                        
+                        Spacer()
+                        
+                        // Status indicators - cleaner design
+                        HStack(spacing: 12 * scale) {
+                            HStack(spacing: 3 * scale) {
+                                Circle()
+                                    .fill(inspectState.colorThresholds.getPositiveColor())
+                                    .frame(width: 8 * scale, height: 8 * scale)
+                                Text("\(getPassedCount())")
+                                    .font(.system(size: 12 * scale, weight: .medium))
+                                    .foregroundColor(inspectState.colorThresholds.getPositiveColor())
+                            }
+                            
+                            HStack(spacing: 3 * scale) {
+                                Circle()
+                                    .fill(inspectState.colorThresholds.getNegativeColor())
+                                    .frame(width: 8 * scale, height: 8 * scale)
+                                Text("\(getFailedCount())")
+                                    .font(.system(size: 12 * scale, weight: .medium))
+                                    .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 32 * scale)
+                .padding(.bottom, 20 * scale)
+            }
+            
+            Spacer()
+            
+            // Category Breakdown Section - Enhanced layout with more space
+            ScrollView {
+                LazyVGrid(columns: [
+                    GridItem(.flexible(), spacing: 16 * scale),
+                    GridItem(.flexible(), spacing: 16 * scale)
+                ], spacing: 12 * scale) {
+                    ForEach(complianceData, id: \.name) { category in
+                        CategoryCardView(category: category, scale: scale, colorThresholds: inspectState.colorThresholds)
+                    }
+                }
+                .padding(.horizontal, 32 * scale)
+            }
+            
+            Spacer()
+            
+            // Bottom Action Area
+            HStack(spacing: 20 * scale) {
+                Button(inspectState.uiConfiguration.popupButtonText) {
+                    showingAboutPopover.toggle()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.blue)
+                .font(.body)
+                .popover(isPresented: $showingAboutPopover, arrowEdge: .top) {
+                    ComplianceDetailsPopoverView(
+                        complianceData: complianceData,
+                        criticalIssues: criticalIssues,
+                        allFailingItems: allFailingItems,
+                        lastCheck: lastCheck,
+                        inspectState: inspectState
+                    )
+                }
+                
+                Spacer()
+                
+                // Action buttons
+                HStack(spacing: 12) {
+                    if inspectState.buttonConfiguration.button2Visible && !inspectState.buttonConfiguration.button2Text.isEmpty {
+                        Button(inspectState.buttonConfiguration.button2Text) {
+                            writeLog("Preset5Layout: User clicked button2 (\(inspectState.buttonConfiguration.button2Text)) - exiting with code 2", logLevel: .info)
+                            exit(2)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                        .disabled(inspectState.buttonConfiguration.button2Disabled)
+                    }
+                    
+                    Button(inspectState.buttonConfiguration.button1Text) {
+                        writeLog("Preset5Layout: User clicked button1 (\(inspectState.buttonConfiguration.button1Text)) - exiting with code 0", logLevel: .info)
+                        exit(0)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(inspectState.buttonConfiguration.button1Disabled)
+                }
+            }
+            .padding(.horizontal, 32 * scale)
+            .padding(.bottom, 30 * scale)
+        }
+        .background(Color(NSColor.windowBackgroundColor))
+        .onAppear {
+            loadComplianceData()
+        }
+        .onChange(of: inspectState.items.count) { _ in
+            loadComplianceData()
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func loadComplianceData() {
+        // Check if we have complex plist sources (for mSCP audit) OR simple item validation
+        let hasComplexPlist = inspectState.plistSources != nil
+        let hasSimpleValidation = inspectState.items.contains { $0.plistKey != nil }
+        let hasRegularItems = !inspectState.items.isEmpty
+        
+        guard hasComplexPlist || hasSimpleValidation || hasRegularItems else {
+            writeLog("Preset5Layout: No configuration found", logLevel: .info)
+            return
+        }
+        
+        // Handle complex plist sources (existing mSCP audit functionality)
+        if let plistSources = inspectState.plistSources {
+            loadComplexPlistData(from: plistSources)
+            return
+        }
+        
+        // Handle simple validation (plist + file existence checks)
+        if hasSimpleValidation || hasRegularItems {
+            loadSimpleItemValidation()
+        }
+    }
+    
+    private func loadComplexPlistData(from plistSources: [InspectConfig.PlistSourceConfig]) {
+        
+        // Memory-safe loading with autorelease pool
+        autoreleasepool {
+            var allItems: [ComplianceItem] = []
+            var latestCheck = ""
+            
+            // Limit concurrent processing to prevent memory spikes
+            let maxSources = 10
+            let sourcesToProcess = Array(plistSources.prefix(maxSources))
+            
+            if plistSources.count > maxSources {
+                writeLog("Preset5Layout: Limiting plist processing to \(maxSources) sources", logLevel: .info)
+            }
+            
+            for source in sourcesToProcess {
+                autoreleasepool {
+                    if let result = loadPlistSource(source: source) {
+                        allItems.append(contentsOf: result.items)
+                        if result.lastCheck > latestCheck {
+                            latestCheck = result.lastCheck
+                        }
+                    }
+                }
+            }
+            
+            // Process data with memory cleanup
+            let processedData = autoreleasepool { () -> ([ComplianceCategory], [ComplianceItem], [ComplianceItem]) in
+                let categories = categorizeItems(allItems)
+                let critical = allItems.filter { !$0.finding && $0.isCritical }
+                let allFailing = allItems.filter { !$0.finding }
+                return (categories, critical, allFailing)
+            }
+            
+            // Update UI state
+            complianceData = processedData.0
+            lastCheck = latestCheck.isEmpty ? getCurrentTimestamp() : latestCheck
+            overallScore = calculateOverallScore(allItems)
+            criticalIssues = processedData.1
+            allFailingItems = processedData.2
+            
+            writeLog("Preset5Layout: Loaded \(allItems.count) items from \(sourcesToProcess.count) plist sources", logLevel: .info)
+        }
+    }
+    
+    private func loadPlistSource(source: InspectConfig.PlistSourceConfig) -> (items: [ComplianceItem], lastCheck: String)? {
+        // Memory safety: Check file size first to avoid loading huge plists
+        let _ = URL(fileURLWithPath: source.path)
+        guard let fileAttributes = try? FileManager.default.attributesOfItem(atPath: source.path),
+              let fileSize = fileAttributes[.size] as? Int64 else {
+            writeLog("Preset5Layout: Unable to get file attributes for \(source.path)", logLevel: .error)
+            return nil
+        }
+        
+        // Prevent loading files larger than 10MB
+        let maxFileSize: Int64 = 10 * 1024 * 1024 // 10MB
+        if fileSize > maxFileSize {
+            writeLog("Preset5Layout: Plist file too large (\(fileSize) bytes) at \(source.path)", logLevel: .error)
+            return nil
+        }
+        
+        // Use autorelease pool for memory management
+        return autoreleasepool { () -> (items: [ComplianceItem], lastCheck: String)? in
+            guard let fileData = FileManager.default.contents(atPath: source.path) else {
+                writeLog("Preset5Layout: Unable to read plist at \(source.path)", logLevel: .error)
+                return nil
+            }
+            
+            do {
+                // Use PropertyListSerialization with explicit cleanup
+                let plistObject = try PropertyListSerialization.propertyList(from: fileData, format: nil)
+                
+                guard let plistContents = plistObject as? [String: Any] else {
+                    writeLog("Preset5Layout: Invalid plist format at \(source.path)", logLevel: .error)
+                    return nil
+                }
+                
+                var items: [ComplianceItem] = []
+                let lastCheck = plistContents["lastComplianceCheck"] as? String ?? 
+                               plistContents["LastUpdateCheck"] as? String ?? 
+                               getCurrentTimestamp()
+                
+                // Process items with memory-conscious approach
+                let maxItems = 1000 // Prevent processing too many items
+                var processedCount = 0
+                
+                for (key, value) in plistContents {
+                    if processedCount >= maxItems {
+                        writeLog("Preset5Layout: Limiting plist processing to \(maxItems) items for \(source.path)", logLevel: .info)
+                        break
+                    }
+                    
+                    if shouldProcessKey(key, source: source) {
+                        if let finding = evaluateValue(value, source: source) {
+                            let item = ComplianceItem(
+                                id: String(key), // Ensure string copy, not reference
+                                category: getCategoryForKey(key, source: source),
+                                finding: finding,
+                                isCritical: isCriticalKey(key, source: source)
+                            )
+                            items.append(item)
+                            processedCount += 1
+                        }
+                    }
+                }
+                
+                writeLog("Preset5Layout: Successfully processed \(items.count) items from \(source.path) (\(fileSize) bytes)", logLevel: .info)
+                return (items, lastCheck)
+                
+            } catch {
+                writeLog("Preset5Layout: Error parsing plist at \(source.path): \(error)", logLevel: .error)
+                return nil
+            }
+        }
+    }
+    
+    private func shouldProcessKey(_ key: String, source: InspectConfig.PlistSourceConfig) -> Bool {
+        // Skip timestamp and metadata keys
+        let skipKeys = ["lastComplianceCheck", "LastUpdateCheck", "CFBundleVersion", "_"]
+        if skipKeys.contains(key) || key.hasPrefix("_") { return false }
+        
+        // If key mappings exist, only process mapped keys
+        if let keyMappings = source.keyMappings {
+            return keyMappings.contains { $0.key == key }
+        }
+        
+        // For compliance type, process all non-metadata keys
+        if source.type == "compliance" {
+            return true
+        }
+        
+        // For other types, be more selective
+        return true
+    }
+    
+    private func evaluateValue(_ value: Any, source: InspectConfig.PlistSourceConfig) -> Bool? {
+        let successValues = source.successValues ?? ["true", "1", "YES"]
+        
+        if let boolValue = value as? Bool {
+            // Check if the boolean value (as string) is in successValues
+            return successValues.contains(String(boolValue))
+        }
+        
+        if let stringValue = value as? String {
+            return successValues.contains(stringValue)
+        }
+        
+        if let numberValue = value as? NSNumber {
+            return successValues.contains(numberValue.stringValue)
+        }
+        
+        if let dictValue = value as? [String: Any] {
+            // For compliance plists with nested structure
+            if let finding = dictValue["finding"] as? Bool {
+                // Check if the boolean finding value is in successValues
+                return successValues.contains(String(finding))
+            }
+        }
+        
+        return nil
+    }
+    
+    private func getCategoryForKey(_ key: String, source: InspectConfig.PlistSourceConfig) -> String {
+        // Check key mappings first
+        if let keyMappings = source.keyMappings {
+            if let mapping = keyMappings.first(where: { $0.key == key }),
+               let category = mapping.category {
+                return category
+            }
+        }
+        
+        // Check category prefixes
+        if let categoryPrefix = source.categoryPrefix {
+            for (prefix, category) in categoryPrefix {
+                if key.hasPrefix(prefix) {
+                    return category
+                }
+            }
+        }
+        
+        // Fallback to source display name or generic categorization
+        return source.displayName
+    }
+    
+    private func isCriticalKey(_ key: String, source: InspectConfig.PlistSourceConfig) -> Bool {
+        // Check key mappings first
+        if let keyMappings = source.keyMappings {
+            if let mapping = keyMappings.first(where: { $0.key == key }),
+               let isCritical = mapping.isCritical {
+                return isCritical
+            }
+        }
+        
+        // Check critical keys list
+        if let criticalKeys = source.criticalKeys {
+            return criticalKeys.contains(key)
+        }
+        
+        return false
+    }
+    
+    // NEW: Simple item validation for non-audit use cases
+    private func loadSimpleItemValidation() {
+        var items: [ComplianceItem] = []
+        
+        for item in inspectState.items {
+            let isValid: Bool
+            
+            // Check if this item needs plist validation
+            if item.plistKey != nil {
+                // Use plist validation
+                isValid = inspectState.validatePlistItem(item)
+            } else {
+                // Simple file existence check
+                isValid = item.paths.first(where: { FileManager.default.fileExists(atPath: $0) }) != nil ||
+                         inspectState.completedItems.contains(item.id)
+            }
+            
+            // Create ComplianceItem from validation result
+            // Use intelligent categorization with multiple fallback options
+            let category: String
+            let isCritical: Bool
+            
+            // Priority 1: Direct category specification
+            if let itemCategory = item.category {
+                category = itemCategory
+                isCritical = false // Can be enhanced later
+            }
+            // Priority 2: plistSources configuration
+            else if let plistKey = item.plistKey,
+                    let firstSource = inspectState.plistSources?.first {
+                category = getCategoryForKey(plistKey, source: firstSource)
+                isCritical = isCriticalKey(plistKey, source: firstSource)
+            }
+            // Priority 3: Fallback for non-plist items
+            else {
+                category = "Applications"
+                isCritical = false
+            }
+            
+            let complianceItem = ComplianceItem(
+                id: item.id,
+                category: category,
+                finding: isValid,
+                isCritical: isCritical
+            )
+            
+            items.append(complianceItem)
+        }
+        
+        // Update UI state with validation results
+        complianceData = categorizeItems(items)
+        lastCheck = getCurrentTimestamp()
+        overallScore = calculateOverallScore(items)
+        criticalIssues = items.filter { !$0.finding && $0.isCritical }
+        allFailingItems = items.filter { !$0.finding }
+        
+        writeLog("Preset5Layout: Loaded \(items.count) items from validation (plist + file checks)", logLevel: .info)
+    }
+    
+    private func getCurrentTimestamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.string(from: Date())
+    }
+    
+    private func categorizeItems(_ items: [ComplianceItem]) -> [ComplianceCategory] {
+        let grouped = Dictionary(grouping: items) { $0.category }
+        
+        return grouped.map { category, items in
+            let passed = items.filter { $0.finding }.count
+            let total = items.count
+            let score = total > 0 ? Double(passed) / Double(total) : 0.0
+            
+            return ComplianceCategory(
+                name: category,
+                passed: passed,
+                total: total,
+                score: score,
+                icon: getCategoryIcon(category)
+            )
+        }.sorted { $0.name < $1.name }
+    }
+    
+    private func categorizeItemID(_ id: String) -> String {
+        if id.hasPrefix("audit_") { return "Audit Controls" }
+        if id.hasPrefix("auth_") { return "Authentication" }
+        if id.hasPrefix("icloud_") { return "iCloud Security" }
+        if id.hasPrefix("os_") { return "OS Security" }
+        if id.hasPrefix("pwpolicy_") { return "Password Policy" }
+        if id.hasPrefix("system_settings_") { return "System Settings" }
+        return "Other"
+    }
+    
+    private func getCategoryIcon(_ category: String) -> String {
+        // Priority 1: Check if any item has specified a custom categoryIcon for this category
+        for item in inspectState.items {
+            if let itemCategory = item.category,
+               itemCategory == category,
+               let categoryIcon = item.categoryIcon {
+                return categoryIcon
+            }
+        }
+        
+        // Priority 2: Check if we have plistSources with an icon configuration
+        if let plistSources = inspectState.plistSources {
+            for source in plistSources {
+                // Check if this category matches any categoryPrefix from this source
+                if let categoryPrefix = source.categoryPrefix {
+                    for (_, prefixCategory) in categoryPrefix {
+                        if prefixCategory == category {
+                            // Use the icon from plistSources configuration
+                            return source.icon ?? "shield"
+                        }
+                    }
+                }
+                // If category matches the source displayName, use source icon
+                if source.displayName == category {
+                    return source.icon ?? "shield"
+                }
+            }
+        }
+        
+        // Priority 3: Simple fallback for common categories
+        return "questionmark.circle"
+    }
+    
+    private func isCriticalItem(_ id: String) -> Bool {
+        let criticalItems = [
+            "os_anti_virus_installed",
+            "os_firmware_password_require",
+            "system_settings_critical_update_install_enforce",
+            "os_sip_enable",
+            "system_settings_firewall_enable"
+        ]
+        return criticalItems.contains(id)
+    }
+    
+    private func calculateOverallScore(_ items: [ComplianceItem]) -> Double {
+        guard !items.isEmpty else { return 0.0 }
+        let passed = items.filter { $0.finding }.count
+        return Double(passed) / Double(items.count)
+    }
+    
+    private func getTotalChecks() -> Int {
+        return complianceData.reduce(0) { $0 + $1.total }
+    }
+    
+    private func getPassedCount() -> Int {
+        return complianceData.reduce(0) { $0 + $1.passed }
+    }
+    
+    private func getFailedCount() -> Int {
+        return getTotalChecks() - getPassedCount()
+    }
+    
+    private func formatIssueTitle(_ id: String) -> String {
+        return id.replacingOccurrences(of: "_", with: " ")
+            .capitalized
+            .trimmingCharacters(in: .whitespaces)
+    }
+    
+}
+
+// MARK: - Supporting Views
+
+struct CategoryRowView: View {
+    let category: ComplianceCategory
+    let scale: CGFloat
+    let colorThresholds: InspectConfig.ColorThresholds
+    
+    var body: some View {
+        HStack(spacing: 16 * scale) {
+            // Category icon
+            Image(systemName: category.icon)
+                .font(.system(size: 20 * scale))
+                .foregroundColor(.blue)
+                .frame(width: 24 * scale)
+            
+            // Category name
+            Text(category.name)
+                .font(.system(size: 16 * scale, weight: .medium))
+                .foregroundColor(.primary)
+            
+            Spacer()
+            
+            // Progress indicator
+            HStack(spacing: 8 * scale) {
+                // Status icon
+                Image(systemName: colorThresholds.getStatusIcon(for: category.score))
+                    .font(.system(size: 14 * scale))
+                    .foregroundColor(colorThresholds.getColor(for: category.score))
+                
+                // Score text
+                Text("\(category.passed)/\(category.total)")
+                    .font(.system(size: 14 * scale, weight: .medium, design: .monospaced))
+                    .foregroundColor(.primary)
+                
+                // Percentage
+                Text("(\(Int(category.score * 100))%)")
+                    .font(.system(size: 14 * scale))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 8 * scale)
+        .padding(.horizontal, 16 * scale)
+        .background(
+            RoundedRectangle(cornerRadius: 8 * scale)
+                .fill(Color.gray.opacity(0.05))
+        )
+    }
+}
+
+struct CategoryCardView: View {
+    let category: ComplianceCategory
+    let scale: CGFloat
+    let colorThresholds: InspectConfig.ColorThresholds
+    
+    var body: some View {
+        VStack(spacing: 8 * scale) {
+            // Header with icon and status
+            HStack {
+                Image(systemName: category.icon)
+                    .font(.system(size: 16 * scale))
+                    .foregroundColor(.blue)
+                
+                Spacer()
+                
+                // Status icon
+                Image(systemName: colorThresholds.getStatusIcon(for: category.score))
+                    .font(.system(size: 14 * scale))
+                    .foregroundColor(colorThresholds.getColor(for: category.score))
+            }
+            
+            // Category name
+            Text(category.name)
+                .font(.system(size: 14 * scale, weight: .medium))
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .frame(minHeight: 28 * scale)
+            
+            // Progress bar - higher contrast
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.4))
+                        .frame(height: 4 * scale)
+                        .cornerRadius(2 * scale)
+                    
+                    Rectangle()
+                        .fill(colorThresholds.getColor(for: category.score))
+                        .frame(width: geometry.size.width * category.score, height: 4 * scale)
+                        .cornerRadius(2 * scale)
+                }
+            }
+            .frame(height: 4 * scale)
+            .overlay(
+                RoundedRectangle(cornerRadius: 2 * scale)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
+            )
+            
+            // Score text
+            Text("\(category.passed)/\(category.total) (\(Int(category.score * 100))%)")
+                .font(.system(size: 12 * scale, weight: .semibold, design: .monospaced))
+                .foregroundColor(.primary)
+        }
+        .padding(12 * scale)
+        .background(
+            RoundedRectangle(cornerRadius: 8 * scale)
+                .fill(Color.gray.opacity(0.05))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8 * scale)
+                        .stroke(Color.gray.opacity(0.1), lineWidth: 1)
+                )
+        )
+    }
+}
+
+struct ComplianceDetailsPopoverView: View {
+    let complianceData: [ComplianceCategory]
+    let criticalIssues: [ComplianceItem]
+    let allFailingItems: [ComplianceItem]
+    let lastCheck: String
+    let inspectState: InspectState
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Security Details")
+                    .font(.headline)
+                
+                Text("Last Check: \(lastCheck)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                
+                // Show all items evaluation details (both plist and file checks)
+                if !inspectState.items.isEmpty {
+                    Divider()
+                    
+                    Text("Item Evaluation Details")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    
+                    // Group items by category for better organization
+                    let groupedItems = Dictionary(grouping: inspectState.items) { item in
+                        item.category ?? "Other"
+                    }
+                    
+                    ForEach(groupedItems.keys.sorted(), id: \.self) { category in
+                        if let categoryItems = groupedItems[category] {
+                            VStack(alignment: .leading, spacing: 12) {
+                                // Category header
+                                HStack {
+                                    Image(systemName: categoryItems.first?.categoryIcon ?? "folder")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(.blue)
+                                    Text(category)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                    
+                                    // Category summary
+                                    let validCount = categoryItems.filter { item in
+                                        isItemValid(item)
+                                    }.count
+                                    
+                                    Text("\(validCount)/\(categoryItems.count)")
+                                        .font(.caption)
+                                        .foregroundColor(validCount == categoryItems.count ? inspectState.colorThresholds.getPositiveColor() : .orange)
+                                }
+                                .padding(.top, 8)
+                    
+                    ForEach(categoryItems.sorted(by: { $0.guiIndex < $1.guiIndex }), id: \.id) { item in
+                        VStack(alignment: .leading, spacing: 8) {
+                            // Item header
+                            HStack {
+                                let isValid = isItemValid(item)
+                                
+                                Circle()
+                                    .fill(inspectState.colorThresholds.getValidationColor(isValid: isValid))
+                                    .frame(width: 8, height: 8)
+                                
+                                Text(item.displayName)
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundColor(.primary)
+                                
+                                Spacer()
+                            }
+                            
+                            // Plist details
+                            if let plistKey = item.plistKey {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    // Key
+                                    HStack {
+                                        Text("Key:")
+                                            .font(.caption.weight(.medium))
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 60, alignment: .leading)
+                                        Text(plistKey)
+                                            .font(.system(.caption, design: .monospaced))
+                                            .textSelection(.enabled)
+                                    }
+                                    
+                                    // Expected value
+                                    if let expectedValue = item.expectedValue {
+                                        HStack {
+                                            Text("Expected:")
+                                                .font(.caption.weight(.medium))
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 60, alignment: .leading)
+                                            Text(expectedValue)
+                                                .font(.system(.caption, design: .monospaced))
+                                                .foregroundColor(.orange)
+                                                .textSelection(.enabled)
+                                        }
+                                    }
+                                    
+                                    // Actual value
+                                    HStack {
+                                        Text("Actual:")
+                                            .font(.caption.weight(.medium))
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 60, alignment: .leading)
+                                        
+                                        if let actualValue = inspectState.getPlistValueForDisplay(item: item) {
+                                            Text(actualValue)
+                                                .font(.system(.caption, design: .monospaced))
+                                                .foregroundColor(inspectState.colorThresholds.getValidationColor(isValid: inspectState.validatePlistItem(item)))
+                                                .textSelection(.enabled)
+                                        } else {
+                                            Text("Key not found")
+                                                .font(.caption)
+                                                .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                                                .italic()
+                                        }
+                                    }
+                                    
+                                    // Path
+                                    if let path = item.paths.first {
+                                        HStack {
+                                            Text("Path:")
+                                                .font(.caption.weight(.medium))
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 60, alignment: .leading)
+                                            Text(path)
+                                                .font(.system(.caption, design: .monospaced))
+                                                .foregroundColor(.secondary)
+                                                .lineLimit(2)
+                                                .textSelection(.enabled)
+                                        }
+                                    }
+                                }
+                                .padding(.leading, 12)
+                            } else {
+                                // File existence check details
+                                VStack(alignment: .leading, spacing: 4) {
+                                    // Evaluation type
+                                    HStack {
+                                        Text("Type:")
+                                            .font(.caption.weight(.medium))
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 60, alignment: .leading)
+                                        Text("File Existence Check")
+                                            .font(.caption)
+                                            .foregroundColor(.blue)
+                                    }
+                                    
+                                    // Check all paths
+                                    ForEach(item.paths, id: \.self) { path in
+                                        let fileExists = FileManager.default.fileExists(atPath: path)
+                                        HStack {
+                                            Text("Path:")
+                                                .font(.caption.weight(.medium))
+                                                .foregroundColor(.secondary)
+                                                .frame(width: 60, alignment: .leading)
+                                            
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(path)
+                                                    .font(.system(.caption, design: .monospaced))
+                                                    .foregroundColor(inspectState.colorThresholds.getValidationColor(isValid: fileExists))
+                                                    .lineLimit(2)
+                                                    .textSelection(.enabled)
+                                                
+                                                Text(fileExists ? "✓ File exists" : "✗ File not found")
+                                                    .font(.caption)
+                                                    .foregroundColor(inspectState.colorThresholds.getValidationColor(isValid: fileExists))
+                                            }
+                                        }
+                                    }
+                                    
+                                    // File info if exists
+                                    if let existingPath = item.paths.first(where: { FileManager.default.fileExists(atPath: $0) }) {
+                                        if let attributes = try? FileManager.default.attributesOfItem(atPath: existingPath) {
+                                            // File size
+                                            if let fileSize = attributes[.size] as? Int64 {
+                                                HStack {
+                                                    Text("Size:")
+                                                        .font(.caption.weight(.medium))
+                                                        .foregroundColor(.secondary)
+                                                        .frame(width: 60, alignment: .leading)
+                                                    Text(ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file))
+                                                        .font(.caption)
+                                                        .foregroundColor(.secondary)
+                                                }
+                                            }
+                                            
+                                            // Modification date
+                                            if let modDate = attributes[.modificationDate] as? Date {
+                                                HStack {
+                                                    Text("Modified:")
+                                                        .font(.caption.weight(.medium))
+                                                        .foregroundColor(.secondary)
+                                                        .frame(width: 60, alignment: .leading)
+                                                    Text(modDate, style: .date)
+                                                        .font(.caption)
+                                                        .foregroundColor(.secondary)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.leading, 12)
+                            }
+                        }
+                        .padding(8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
+                        )
+                    }
+                            } // End VStack for category
+                        } // End if let categoryItems
+                    } // End ForEach categories
+                } // End if !inspectState.items.isEmpty
+                
+                if inspectState.items.isEmpty && !allFailingItems.isEmpty {
+                    // Show enhanced audit issues for complex validation
+                    Divider()
+                    
+                    // Enhanced header with context
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Image(systemName: "exclamationmark.shield.fill")
+                                .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                                .font(.subheadline)
+                            Text("Security Compliance Issues")
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                        }
+                        
+                        // Show audit source context
+                        if let plistSources = inspectState.plistSources,
+                           let firstSource = plistSources.first {
+                            Text("Source: \(firstSource.displayName)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        
+                        Text("The following controls require attention:")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.bottom, 8)
+                    
+                    // Show all failing compliance items, with critical ones first
+                    let sortedFailingItems = getAllFailingComplianceItems()
+                    ForEach(sortedFailingItems, id: \.id) { issue in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                                    .font(.caption)
+                                
+                                Text(formatAuditControlTitle(issue.id))
+                                    .font(.caption.weight(.medium))
+                                    .foregroundColor(.primary)
+                                
+                                Spacer()
+                                
+                                // Show category badge
+                                Text(issue.category)
+                                    .font(.system(.caption2))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Color.orange.opacity(0.2))
+                                    .foregroundColor(.orange)
+                                    .cornerRadius(4)
+                            }
+                            
+                            // Show control description/context from config
+                            if let context = getContextFromPlistSources(for: issue.id) {
+                                Text(context)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                    .padding(.leading, 16)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                    
+                    // Summary footer with correct counts
+                    let totalFailingCount = sortedFailingItems.count
+                    let criticalFailingCount = sortedFailingItems.filter { $0.isCritical }.count
+                    
+                    if totalFailingCount > 0 {
+                        Divider()
+                            .padding(.vertical, 4)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Image(systemName: "info.circle")
+                                    .foregroundColor(.blue)
+                                    .font(.caption)
+                                
+                                Text("\(totalFailingCount) control(s) need remediation")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            if criticalFailingCount > 0 {
+                                HStack {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                                        .font(.caption)
+                                    
+                                    Text("\(criticalFailingCount) are critical priority")
+                                        .font(.caption)
+                                        .foregroundColor(inspectState.colorThresholds.getNegativeColor())
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .frame(maxWidth: 500, maxHeight: 400)
+    }
+    
+    // Helper function to validate items
+    private func isItemValid(_ item: InspectConfig.ItemConfig) -> Bool {
+        if item.plistKey != nil {
+            return inspectState.validatePlistItem(item)
+        } else {
+            return item.paths.first(where: { FileManager.default.fileExists(atPath: $0) }) != nil
+        }
+    }
+    
+    // Enhanced formatting for audit control titles using config data
+    private func formatAuditControlTitle(_ id: String) -> String {
+        // Use keyMappings from plistSources if available for custom titles
+        if let plistSources = inspectState.plistSources {
+            for source in plistSources {
+                if let keyMappings = source.keyMappings {
+                    if let mapping = keyMappings.first(where: { $0.key == id }),
+                       let displayName = mapping.displayName {
+                        return displayName
+                    }
+                }
+            }
+        }
+        
+        // Fallback: smart prefix removal and formatting
+        var cleanedId = id
+        if let plistSources = inspectState.plistSources,
+           let firstSource = plistSources.first,
+           let categoryPrefix = firstSource.categoryPrefix {
+            // Remove category prefixes dynamically
+            for (prefix, _) in categoryPrefix {
+                if id.hasPrefix(prefix) {
+                    cleanedId = String(id.dropFirst(prefix.count))
+                    break
+                }
+            }
+        }
+        
+        // Convert underscores to spaces and capitalize
+        return cleanedId
+            .replacingOccurrences(of: "_", with: " ")
+            .capitalized
+            .trimmingCharacters(in: .whitespaces)
+    }
+    
+    // Get context/description from plistSources configuration
+    private func getContextFromPlistSources(for id: String) -> String? {
+        guard let plistSources = inspectState.plistSources else { return nil }
+        
+        for source in plistSources {
+            // Check if source has a general description for critical keys
+            if let criticalKeys = source.criticalKeys,
+               criticalKeys.contains(id) {
+                return "Critical security control - requires immediate attention"
+            }
+        }
+        
+        return nil
+    }
+    
+    // Check if there are any failing compliance items (beyond just critical ones)
+    private func hasFailingComplianceItems() -> Bool {
+        return !allFailingItems.isEmpty
+    }
+    
+    // Get all failing compliance items, with critical ones first
+    private func getAllFailingComplianceItems() -> [ComplianceItem] {
+        // Sort so critical items appear first
+        return allFailingItems.sorted { item1, item2 in
+            if item1.isCritical && !item2.isCritical {
+                return true // Critical items first
+            } else if !item1.isCritical && item2.isCritical {
+                return false
+            } else {
+                return item1.category < item2.category // Then by category
+            }
+        }
+    }
+    
+    // Helper to determine if an item is critical based on plistSources
+    private func isCriticalItem(_ id: String) -> Bool {
+        guard let plistSources = inspectState.plistSources,
+              let firstSource = plistSources.first,
+              let criticalKeys = firstSource.criticalKeys else {
+            return false
+        }
+        return criticalKeys.contains(id)
+    }
+}
+
+// MARK: - Data Models
+
+struct ComplianceItem {
+    let id: String
+    let category: String
+    let finding: Bool
+    let isCritical: Bool
+}
+
+struct ComplianceCategory {
+    let name: String
+    let passed: Int
+    let total: Int
+    let score: Double
+    let icon: String
+}

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -214,17 +214,27 @@ struct dialogApp: App {
     }
 
     var body: some Scene {
-
+        
         WindowGroup {
             if !appArguments.notification.present && !appvars.noargs {
+                let _ = appvars.debugMode ? print("DEBUG: Checking modes - mini:\(appArguments.miniMode.present) inspect:\(appArguments.inspectMode.present) presentation:\(appArguments.presentationMode.present)") : ()
                 ZStack {
                     if appArguments.miniMode.present {
+                        let _ = appvars.debugMode ? print("DEBUG: Loading MiniView") : ()
                         MiniView(observedDialogContent: observedData)
                             .frame(width: observedData.appProperties.windowWidth, height: observedData.appProperties.windowHeight)
+                    } else if appArguments.inspectMode.present {
+                        // Wrap InspectView to delay its initialization
+                        let _ = appvars.debugMode ? print("DEBUG: Loading InspectView") : ()
+                        InspectView()
+                            .frame(width: observedData.appProperties.windowWidth, 
+                                  height: observedData.appProperties.windowHeight)
                     } else if appArguments.presentationMode.present {
+                        let _ = appvars.debugMode ? print("DEBUG: Loading PresentationView") : ()
                         PresentationView(observedData: observedData)
                             .frame(width: observedData.appProperties.windowWidth, height: observedData.appProperties.windowHeight)
                     } else {
+                        let _ = appvars.debugMode ? print("DEBUG: Loading default ContentView") : ()
                         if appArguments.windowResizable.present {
                             ContentView(observedDialogContent: observedData)
                         } else {
@@ -243,6 +253,7 @@ struct dialogApp: App {
                             appArguments.movableWindow.present = true
                         }
                     }
+                    
                 }
                 .preferredColorScheme(observedData.args.preferredAppearance.present &&
                                       observedData.args.preferredAppearance.value.lowercased() == "dark" ? .dark


### PR DESCRIPTION
- Supports inspect on files, folders existence, and introspect plist configurations
- Basic plist validation types (exists, boolean, contains, range, equals)
- Includes 5 preset layouts for common enrollment progress and inspection tasks
- Uses file system events (FSEvents) to trigger UI updates
- Integrates InspectValidationService and InspectConfigurationService into Xcode build system
- Moved AppInspector startup to InspectState for better handling
- Due to build errors updated MarkdownUI from 2.3.0 to 2.4.1

Adds 17 new files and modifies 5 existing ones.
Usage: DIALOG_INSPECT_CONFIG=/path/to/inspect_config.json /usr/local/bin/dialog --inspect-mode