### PR TITLE
Fixed some Dutch translations

### DIFF
--- a/dialog/extras/Localisations/nl.lproj/Localizable.strings
+++ b/dialog/extras/Localisations/nl.lproj/Localizable.strings
@@ -39,7 +39,8 @@
 "Window"             = "Venster";
 "Sidebar"            = "Zijbalk";
 "Data Entry"          = "Gegevensinvoer";
-"Buttons"            = "Toetsen";
+"Buttons"            = "Knoppen";
+"Button Size"       = "Knopgrootte";
 "Advanced"           = "Geavanceerd";
 "List Items"          = "Lijstitems";
 "Images"             = "Afbeeldingen";
@@ -49,7 +50,7 @@
 "Quit"              = "Afsluiten";
 "Export Command"      = "Exportopdracht";
 "Title"              = "Titel";
-"Colour"             = "Kleur";
+"Color"             = "Kleur";
 "Reset"              = "Resetten";
 "Font Size: "           = "Lettertypegrootte: ";
 "value:"              = "waarde:";


### PR DESCRIPTION
Corrected some Dutch translations that didn't read particularly naturally. 
The one for "Disabled" in particular translates to the Dutch word for a medical disability - this has been corrected :)