### PR TITLE
Cleanup postinstall

### DIFF
--- a/dialog/Package/Scripts/postinstall
+++ b/dialog/Package/Scripts/postinstall
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-base_dir="${PWD}"
-
 dialog_root="$3/Library/Application Support/Dialog"
 iconfile="${dialog_root}/Dialog.png"
 dialogbundle="${dialog_root}/Dialog.app"
 localisedbundle="${dialog_root}/Dialog.localized/Dialog.app"
 dialogbinary="${dialogbundle}/Contents/MacOS/Dialog"
-enrolmentScript="${dialog_root}/swiftDialogEnrolment.sh"
 log_file="${dialog_root}/postinstall.log"
 
 write_to_log() {


### PR DESCRIPTION
The enrollment script functionality was removed in 2.5.1.

The `base_dir` variable supported the custom icon feature that was embedded in the Dialog binary in 2.5.3.

Cleaning these up for clarity when reading.