### PR TITLE
Add minimize and deminimize functions to swiftDialog

### DIFF
--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -537,8 +537,8 @@ class FileReader {
                     blurredScreen.hide()
                 }
                 NSApp.hide(self)
-
-            // hide
+                
+            // show
             case "show:":
                 writeToLog("Showing windows")
                 if observedData.args.blurScreen.present {
@@ -546,6 +546,25 @@ class FileReader {
                 }
                 NSApp.unhide(self)
                 activateDialog()
+
+            // minimize
+            case "miniaturize:":
+                writeToLog("minimizing windows")
+                if observedData.args.blurScreen.present {
+                    blurredScreen.hide()
+                }
+                NSApp.keyWindow?.setIsMiniaturized(true)
+
+            // deminimize
+            case "deminiaturize:":
+                writeToLog("deminimizing windows")
+                if observedData.args.blurScreen.present {
+                    blurredScreen.show()
+                }
+                // Find all minimized windows, ordered by recentness (0 is frontmost)
+                let minimizedWindows = NSApp.windows.filter { $0.isMiniaturized }
+                // Deminimize the first one found (most recent)
+                minimizedWindows.first?.deminiaturize(nil)
 
             // icon alpha
             case "\(observedData.args.iconAlpha.long):":


### PR DESCRIPTION
Adds ***miniaturize:*** and ***deminiaturize:*** commands to list of functions you can call from a command file.

**miniaturize:** causes the swiftDialog window to minimize to the users Dock.

**deminiaturize:** causes the last minimized item put into the Dock to return as the active window.

Both commands will honor blurscreen and turn it off (for miniaturize) or back on (for deminiaturize) as needed, similar to the **hide:** and **show:** commands when it is enabled.