### PR TITLE
Release/3.1.0

### DIFF
--- a/DialogNotifier/Info-Alert.plist
+++ b/DialogNotifier/Info-Alert.plist
@@ -20,6 +20,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSUserNotificationAlertStyle</key>

--- a/DialogNotifier/Info-Alert.plist
+++ b/DialogNotifier/Info-Alert.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
+</dict>
+</plist>

--- a/DialogNotifier/Info-Banner.plist
+++ b/DialogNotifier/Info-Banner.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>banner</string>
+</dict>
+</plist>

--- a/DialogNotifier/Info-Banner.plist
+++ b/DialogNotifier/Info-Banner.plist
@@ -20,6 +20,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSUserNotificationAlertStyle</key>

--- a/DialogNotifier/NotifierApp.swift
+++ b/DialogNotifier/NotifierApp.swift
@@ -18,16 +18,47 @@ class NotifierAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCe
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Request authorisation (non-blocking; completion fires asynchronously)
-        requestNotificationAuthorisation()
+        let capturedArgs = args
+        Task {
+            await runNotifierFlow(args: capturedArgs)
+        }
+    }
+
+    // Main async flow — awaiting authorisation keeps the app alive
+    // for exactly as long as the permission prompt is visible.
+    private func runNotifierFlow(args: NotifierArguments) async {
+        let center = UNUserNotificationCenter.current()
+
+        // Check current status first so we only prompt when genuinely undetermined.
+        let settings = await center.notificationSettings()
+
+        if settings.authorizationStatus == .notDetermined {
+            writeLog("Requesting notification authorisation", logLevel: .debug)
+            do {
+                // This await returns only after the user taps Allow or Don't Allow,
+                // so the app stays alive for the duration of the permission prompt.
+                let granted = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+                writeLog("Notification authorisation \(granted ? "granted" : "denied")", logLevel: .debug)
+                if !granted {
+                    await MainActor.run { NSApp.terminate(nil) }
+                    return
+                }
+            } catch {
+                writeLog(error.localizedDescription, logLevel: .error)
+                await MainActor.run { NSApp.terminate(nil) }
+                return
+            }
+        } else if settings.authorizationStatus == .denied {
+            writeLog("Notifications are denied — nothing to send", logLevel: .error)
+            await MainActor.run { NSApp.terminate(nil) }
+            return
+        }
 
         if args.removeNotification {
             writeLog("Removing notification(s)")
             removeNotification(identifier: args.identifier.isEmpty ? nil : args.identifier)
-            // Small delay to let the removal propagate before quitting
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                NSApp.terminate(nil)
-            }
+            try? await Task.sleep(for: .milliseconds(500))
+            await MainActor.run { NSApp.terminate(nil) }
             return
         }
 
@@ -45,11 +76,10 @@ class NotifierAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCe
             soundEnabled: args.soundEnabled
         )
 
-        // Allow time for the notification to be delivered before quitting.
-        // The system delivers it asynchronously; 0.5 s is sufficient in practice.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            NSApp.terminate(nil)
-        }
+        // Small delay to ensure the notification request has been handed off
+        // to the system before we exit.
+        try? await Task.sleep(for: .milliseconds(500))
+        await MainActor.run { NSApp.terminate(nil) }
     }
 
     // MARK: - UNUserNotificationCenterDelegate

--- a/DialogNotifier/NotifierApp.swift
+++ b/DialogNotifier/NotifierApp.swift
@@ -1,0 +1,83 @@
+//
+//  NotifierApp.swift
+//  DialogNotifier
+//
+//  App delegate for the DialogNotifier helper. Entry point is in main.swift.
+//
+
+import AppKit
+import UserNotifications
+
+class NotifierAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+
+    private let args = NotifierArguments()
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        notifierDebugMode = args.debugMode
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Request authorisation (non-blocking; completion fires asynchronously)
+        requestNotificationAuthorisation()
+
+        if args.removeNotification {
+            writeLog("Removing notification(s)")
+            removeNotification(identifier: args.identifier.isEmpty ? nil : args.identifier)
+            // Small delay to let the removal propagate before quitting
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApp.terminate(nil)
+            }
+            return
+        }
+
+        writeLog("Sending notification")
+        sendNotification(
+            title: args.title,
+            subtitle: args.subtitle,
+            message: args.message,
+            image: args.icon,
+            identifier: args.identifier,
+            acceptString: args.button1Text,
+            acceptAction: args.button1Action,
+            declineString: args.button2Text,
+            declineAction: args.button2Action,
+            soundEnabled: args.soundEnabled
+        )
+
+        // Allow time for the notification to be delivered before quitting.
+        // The system delivers it asynchronously; 0.5 s is sufficient in practice.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            NSApp.terminate(nil)
+        }
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Called when the user interacts with a delivered notification.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        writeLog("Received notification response", logLevel: .debug)
+
+        if response.notification.request.content.categoryIdentifier == "SD_NOTIFICATION" {
+            processNotification(response: response)
+        } else {
+            writeLog("Unknown notification category", logLevel: .debug)
+        }
+
+        completionHandler()
+        NSApp.terminate(nil)
+    }
+
+    /// Called when a notification arrives while the app is in the foreground.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+}

--- a/DialogNotifier/NotifierArguments.swift
+++ b/DialogNotifier/NotifierArguments.swift
@@ -1,0 +1,69 @@
+//
+//  NotifierArguments.swift
+//  DialogNotifier
+//
+//  Minimal CLI argument parser for notification-relevant flags only.
+//
+
+import Foundation
+
+struct NotifierArguments {
+    var title: String = ""
+    var subtitle: String = ""
+    var message: String = ""
+    var icon: String = ""
+    var button1Text: String = ""
+    var button1Action: String = ""
+    var button2Text: String = ""
+    var button2Action: String = ""
+    var identifier: String = ""
+    var soundEnabled: Bool = false
+    var removeNotification: Bool = false
+    var debugMode: Bool = false
+
+    init() {
+        let args = CommandLine.arguments
+        var i = 1
+        while i < args.count {
+            let arg = args[i]
+            switch arg {
+            case "--title", "-t":
+                title = nextValue(args: args, index: &i)
+            case "--subtitle":
+                subtitle = nextValue(args: args, index: &i)
+            case "--message", "-m":
+                message = nextValue(args: args, index: &i)
+            case "--icon", "-i":
+                icon = nextValue(args: args, index: &i)
+            case "--button1text":
+                button1Text = nextValue(args: args, index: &i)
+            case "--button1action":
+                button1Action = nextValue(args: args, index: &i)
+            case "--button2text":
+                button2Text = nextValue(args: args, index: &i)
+            case "--button2action":
+                button2Action = nextValue(args: args, index: &i)
+            case "--identifier", "-id":
+                identifier = nextValue(args: args, index: &i)
+            case "--enablenotificationsounds":
+                soundEnabled = true
+            case "--remove":
+                removeNotification = true
+            case "--debug":
+                debugMode = true
+            default:
+                break
+            }
+            i += 1
+        }
+    }
+
+    // Reads the next argument as a value, advancing the index.
+    // Returns empty string if the next token starts with "--" or is absent.
+    private func nextValue(args: [String], index: inout Int) -> String {
+        let next = index + 1
+        guard next < args.count, !args[next].hasPrefix("-") else { return "" }
+        index = next
+        return args[next]
+    }
+}

--- a/DialogNotifier/NotifierImages.swift
+++ b/DialogNotifier/NotifierImages.swift
@@ -1,0 +1,73 @@
+//
+//  NotifierImages.swift
+//  DialogNotifier
+//
+//  Image utilities needed by the notifier helper. SwiftUI-free, no quitDialog dependency.
+//
+
+import Foundation
+import AppKit
+
+func getImageFromPath(fileImagePath: String, returnErrorImage: Bool = false) -> NSImage? {
+    writeLog("Getting image from path \(fileImagePath)")
+
+    let errorImage = NSImage(
+        systemSymbolName: "questionmark.square.dashed",
+        accessibilityDescription: nil
+    )
+
+    // Base64 image data
+    if fileImagePath.hasPrefix("base64") {
+        return getImageFromBase64(base64String: fileImagePath.replacing("base64=", with: ""))
+    }
+
+    let urlPath: URL
+    if fileImagePath.hasPrefix("http") {
+        guard let url = URL(string: fileImagePath) else {
+            return returnErrorImage ? errorImage : nil
+        }
+        urlPath = url
+    } else {
+        urlPath = URL(fileURLWithPath: fileImagePath)
+    }
+
+    guard let imageData = try? Data(contentsOf: urlPath) else {
+        writeLog("Could not load image data from \(fileImagePath)", logLevel: .error)
+        return returnErrorImage ? errorImage : nil
+    }
+
+    return NSImage(data: imageData) ?? errorImage
+}
+
+func getImageFromBase64(base64String: String) -> NSImage? {
+    guard let imageData = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters) else {
+        return nil
+    }
+    return NSImage(data: imageData)
+}
+
+func getAppIcon(appPath: String, withSize: CGFloat = 300) -> NSImage {
+    writeLog("Getting app icon from \(appPath)")
+    let image = NSImage()
+    if let rep = NSWorkspace.shared.icon(forFile: appPath)
+        .bestRepresentation(for: NSRect(x: 0, y: 0, width: withSize, height: withSize),
+                            context: nil, hints: nil) {
+        image.size = rep.size
+        image.addRepresentation(rep)
+    }
+    return image
+}
+
+func savePNG(image: NSImage, path: String) {
+    guard let tiff = image.tiffRepresentation,
+          let rep = NSBitmapImageRep(data: tiff),
+          let pngData = rep.representation(using: .png, properties: [:]) else {
+        writeLog("Failed to convert image to PNG", logLevel: .error)
+        return
+    }
+    do {
+        try pngData.write(to: URL(fileURLWithPath: path))
+    } catch {
+        writeLog("Failed to save PNG to \(path): \(error)", logLevel: .error)
+    }
+}

--- a/DialogNotifier/NotifierLog.swift
+++ b/DialogNotifier/NotifierLog.swift
@@ -1,0 +1,43 @@
+//
+//  NotifierLog.swift
+//  DialogNotifier
+//
+//  Minimal logging for the notifier helper — no dependency on appvars or appArguments.
+//
+
+import Foundation
+import OSLog
+
+let notifierLog = OSLog(
+    subsystem: Bundle.main.bundleIdentifier ?? "au.csiro.dialog.notifier",
+    category: "main"
+)
+
+var notifierDebugMode = false
+
+struct StandardError: TextOutputStream {
+    func write(_ string: String) {
+        fputs(string, stderr)
+    }
+}
+
+func writeLog(_ message: String, logLevel: OSLogType = .info, log: OSLog = notifierLog) {
+    os_log("%{public}@", log: log, type: logLevel, message)
+    if logLevel == .error || notifierDebugMode {
+        var standardError = StandardError()
+        print("\(logLevel.stringValue.uppercased()): \(message)", to: &standardError)
+    }
+}
+
+extension OSLogType {
+    var stringValue: String {
+        switch self {
+        case .default: return "default"
+        case .info:    return "info"
+        case .debug:   return "debug"
+        case .error:   return "error"
+        case .fault:   return "fault"
+        default:       return "unknown"
+        }
+    }
+}

--- a/DialogNotifier/NotifierNotifications.swift
+++ b/DialogNotifier/NotifierNotifications.swift
@@ -9,15 +9,6 @@ import Foundation
 import UserNotifications
 import AppKit
 
-func requestNotificationAuthorisation() {
-    writeLog("Requesting notification authorisation", logLevel: .debug)
-    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, error in
-        if let error {
-            writeLog(error.localizedDescription, logLevel: .error)
-        }
-    }
-}
-
 func removeNotification(identifier: String? = nil) {
     let center = UNUserNotificationCenter.current()
     if let id = identifier, !id.isEmpty {

--- a/DialogNotifier/NotifierNotifications.swift
+++ b/DialogNotifier/NotifierNotifications.swift
@@ -1,0 +1,171 @@
+//
+//  NotifierNotifications.swift
+//  DialogNotifier
+//
+//  Notification send/remove/response logic, adapted from dialog's Notifications.swift.
+//
+
+import Foundation
+import UserNotifications
+import AppKit
+
+func requestNotificationAuthorisation() {
+    writeLog("Requesting notification authorisation", logLevel: .debug)
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, error in
+        if let error {
+            writeLog(error.localizedDescription, logLevel: .error)
+        }
+    }
+}
+
+func removeNotification(identifier: String? = nil) {
+    let center = UNUserNotificationCenter.current()
+    if let id = identifier, !id.isEmpty {
+        center.removeDeliveredNotifications(withIdentifiers: [id])
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+        writeLog("Removed notification with identifier: \(id)")
+    } else {
+        center.removeAllDeliveredNotifications()
+        center.removeAllPendingNotificationRequests()
+        writeLog("Removed all notifications")
+    }
+}
+
+func sendNotification(
+    title: String = "",
+    subtitle: String = "",
+    message: String = "",
+    image: String = "",
+    identifier: String = "",
+    acceptString: String = "Open",
+    acceptAction: String = "",
+    declineString: String = "Close",
+    declineAction: String = "",
+    soundEnabled: Bool = false
+) {
+    let center = UNUserNotificationCenter.current()
+    let tempImagePath = "/var/tmp/sdnotification.png"
+
+    // Build action buttons
+    var actions: [UNNotificationAction] = []
+    if !acceptString.isEmpty {
+        actions.append(UNNotificationAction(identifier: "ACCEPT_ACTION_LABEL",
+                                            title: acceptString, options: []))
+    }
+    if !declineString.isEmpty {
+        actions.append(UNNotificationAction(identifier: "DECLINE_ACTION_LABEL",
+                                            title: declineString, options: []))
+    }
+
+    // Prepare icon attachment
+    if !image.isEmpty {
+        var importedImage: NSImage
+
+        if image.hasSuffix(".app") || image.hasSuffix("prefPane") {
+            importedImage = getAppIcon(appPath: image)
+        } else if image.lowercased().hasPrefix("sf=") {
+            let config = NSImage.SymbolConfiguration(pointSize: 128, weight: .thin)
+            importedImage = NSImage(
+                systemSymbolName: String(image.dropFirst(3)),
+                accessibilityDescription: "SF Symbol"
+            )?.withSymbolConfiguration(config) ?? NSImage(
+                systemSymbolName: "applelogo",
+                accessibilityDescription: nil
+            )!
+        } else {
+            importedImage = getImageFromPath(fileImagePath: image, returnErrorImage: true)
+                ?? NSImage(systemSymbolName: "applelogo", accessibilityDescription: nil)!
+        }
+
+        savePNG(image: importedImage, path: tempImagePath)
+    }
+
+    // Register notification category
+    let category = UNNotificationCategory(
+        identifier: "SD_NOTIFICATION",
+        actions: actions,
+        intentIdentifiers: [],
+        hiddenPreviewsBodyPlaceholder: "",
+        options: .customDismissAction
+    )
+    center.setNotificationCategories([category])
+
+    center.getNotificationSettings { settings in
+        guard settings.authorizationStatus == .authorized ||
+              settings.authorizationStatus == .provisional else {
+            writeLog("Notifications not authorised (status: \(settings.authorizationStatus.rawValue))", logLevel: .error)
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.subtitle = subtitle
+        content.body = message
+        content.userInfo = ["ACCEPT_ACTION": acceptAction, "DECLINE_ACTION": declineAction]
+        content.categoryIdentifier = "SD_NOTIFICATION"
+
+        if soundEnabled {
+            content.sound = .default
+        }
+
+        // Attach image if present
+        if !image.isEmpty {
+            do {
+                let attachment = try UNNotificationAttachment(
+                    identifier: "AttachedContent",
+                    url: URL(fileURLWithPath: tempImagePath),
+                    options: nil
+                )
+                content.attachments = [attachment]
+            } catch {
+                writeLog(error.localizedDescription, logLevel: .error)
+            }
+        }
+
+        let request = UNNotificationRequest(
+            identifier: identifier.isEmpty ? UUID().uuidString : identifier,
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request) { error in
+            if let error {
+                writeLog(error.localizedDescription, logLevel: .error)
+            }
+        }
+    }
+}
+
+func processNotification(response: UNNotificationResponse) {
+    let userInfo = response.notification.request.content.userInfo
+    let acceptAction = userInfo["ACCEPT_ACTION"] as? String ?? ""
+    let declineAction = userInfo["DECLINE_ACTION"] as? String ?? ""
+
+    writeLog("acceptAction: \(acceptAction)")
+    writeLog("declineAction: \(declineAction)")
+
+    switch response.actionIdentifier {
+    case "ACCEPT_ACTION_LABEL", UNNotificationDefaultActionIdentifier:
+        writeLog("user accepted", logLevel: .debug)
+        notificationAction(acceptAction)
+
+    case "DECLINE_ACTION_LABEL":
+        writeLog("user declined", logLevel: .debug)
+        notificationAction(declineAction)
+
+    case UNNotificationDismissActionIdentifier:
+        writeLog("notification dismissed", logLevel: .debug)
+
+    default:
+        break
+    }
+}
+
+func notificationAction(_ action: String) {
+    writeLog("Processing notification action: \(action)")
+    if action.contains("://") {
+        openSpecifiedURL(urlToOpen: action)
+    } else if !action.isEmpty {
+        _ = shell(action)
+    }
+}

--- a/DialogNotifier/NotifierSystem.swift
+++ b/DialogNotifier/NotifierSystem.swift
@@ -1,0 +1,29 @@
+//
+//  NotifierSystem.swift
+//  DialogNotifier
+//
+//  Minimal system utilities needed by the notifier helper.
+//
+
+import Foundation
+import AppKit
+
+func openSpecifiedURL(urlToOpen: String) {
+    writeLog("Opening URL \(urlToOpen)")
+    if let url = URL(string: urlToOpen) {
+        NSWorkspace.shared.open(url)
+    }
+}
+
+func shell(_ command: String) -> String {
+    writeLog("Running shell command \(command)")
+    let task = Process()
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.standardError = pipe
+    task.arguments = ["-c", command]
+    task.launchPath = "/bin/zsh"
+    task.launch()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
+}

--- a/DialogNotifier/main.swift
+++ b/DialogNotifier/main.swift
@@ -1,0 +1,13 @@
+//
+//  main.swift
+//  DialogNotifier
+//
+//  Application entry point. Top-level expressions are only valid in main.swift.
+//
+
+import AppKit
+
+let app = NSApplication.shared
+let delegate = NotifierAppDelegate()
+app.delegate = delegate
+app.run()

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		411FC34628E2DDFD003EA2C2 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411FC34528E2DDFD003EA2C2 /* Notifications.swift */; };
 		4124EFD229455861003B00F4 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4124EFD129455861003B00F4 /* HelpView.swift */; };
 		412B26AF289CE02100493EFF /* MiniView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B26AE289CE02100493EFF /* MiniView.swift */; };
+		413563AA2F50231B006D177B /* CardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413563A92F50231B006D177B /* CardState.swift */; };
 		414550AA27C799D000D756E3 /* BackgroundBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414550A927C799D000D756E3 /* BackgroundBlur.swift */; };
 		41512CC2286C77F200F22B86 /* ConstructionKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41512CC1286C77F200F22B86 /* ConstructionKitView.swift */; };
 		4153784E2604B71800AA0E76 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153784D2604B71800AA0E76 /* TitleView.swift */; };
@@ -240,6 +241,7 @@
 		411FC34528E2DDFD003EA2C2 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Notifications.swift; path = dialog/Functions/Notifications.swift; sourceTree = SOURCE_ROOT; };
 		4124EFD129455861003B00F4 /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		412B26AE289CE02100493EFF /* MiniView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniView.swift; sourceTree = "<group>"; };
+		413563A92F50231B006D177B /* CardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardState.swift; sourceTree = "<group>"; };
 		414550A927C799D000D756E3 /* BackgroundBlur.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundBlur.swift; sourceTree = "<group>"; };
 		41512CC1286C77F200F22B86 /* ConstructionKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstructionKitView.swift; sourceTree = "<group>"; };
 		4153784D2604B71800AA0E76 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
@@ -795,6 +797,7 @@
 				41D6FE8426DB11BA0083BE61 /* jamfHelper.swift */,
 				A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */,
 				F9F647DDE9CB42EBA9D931B9 /* FileSystemCache.swift */,
+				413563A92F50231B006D177B /* CardState.swift */,
 			);
 			path = "App Processing";
 			sourceTree = "<group>";
@@ -1191,6 +1194,7 @@
 				B4608E5B819446BC9AADDC8F /* FileSystemCache.swift in Sources */,
 				412B26AF289CE02100493EFF /* MiniView.swift in Sources */,
 				41BD41C02EA1B6E000DA7124 /* AudioManager.swift in Sources */,
+				413563AA2F50231B006D177B /* CardState.swift in Sources */,
 				BA2812002EBA161C00384582 /* InspectPersistence.swift in Sources */,
 				41BD41C22EA1B71200DA7124 /* AudioControl.swift in Sources */,
 				CC21905D2A7BD7D300269525 /* AppVariables.swift in Sources */,

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		418A7B582759949B00E4D6F1 /* NSWindow+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415934D926DB7604009C9C3A /* NSWindow+Additions.swift */; };
 		418A7B592759949B00E4D6F1 /* HelpText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A44EB126F4C43A00FEE1AC /* HelpText.swift */; };
 		418AE4232667A17A001E3423 /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418AE4222667A17A001E3423 /* DropdownView.swift */; };
+		418B93D62F5151C3004CE17A /* CARDS_FEATURE_DOCUMENTATION.md in Resources */ = {isa = PBXBuildFile; fileRef = 418B93D52F5151C3004CE17A /* CARDS_FEATURE_DOCUMENTATION.md */; };
 		419D11462E73E62400298C8C /* IndeterminateProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419D11452E73E62400298C8C /* IndeterminateProgressView.swift */; };
 		41A5A6A428E5468100BD3D5E /* WebViewKit in Frameworks */ = {isa = PBXBuildFile; productRef = 41A5A6A328E5468100BD3D5E /* WebViewKit */; };
 		41A5A6A628E546A000BD3D5E /* WebContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A5A6A528E546A000BD3D5E /* WebContentView.swift */; };
@@ -281,6 +282,7 @@
 		41832B7A284436E50062AA1F /* da-DK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "da-DK"; path = "da-DK.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		41876682275D87C70023A6A1 /* ImageSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageSlider.swift; sourceTree = "<group>"; };
 		418AE4222667A17A001E3423 /* DropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownView.swift; sourceTree = "<group>"; };
+		418B93D52F5151C3004CE17A /* CARDS_FEATURE_DOCUMENTATION.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CARDS_FEATURE_DOCUMENTATION.md; sourceTree = "<group>"; };
 		419D11452E73E62400298C8C /* IndeterminateProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressView.swift; sourceTree = "<group>"; };
 		41A44EAF26F2F25200FEE1AC /* WatermarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkView.swift; sourceTree = "<group>"; };
 		41A44EB126F4C43A00FEE1AC /* HelpText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpText.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 				4154C2E625F76BDC00A3D373 /* Info.plist */,
 				4154C2E725F76BDC00A3D373 /* dialog.entitlements */,
 				4154C2E325F76BDC00A3D373 /* Preview Content */,
+				418B93D52F5151C3004CE17A /* CARDS_FEATURE_DOCUMENTATION.md */,
 			);
 			path = dialog;
 			sourceTree = "<group>";
@@ -1010,6 +1013,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				418B93D62F5151C3004CE17A /* CARDS_FEATURE_DOCUMENTATION.md in Resources */,
 				41832B7228436B430062AA1F /* Localizable.strings in Resources */,
 				4154C2E225F76BDC00A3D373 /* Assets.xcassets in Resources */,
 			);

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -1433,7 +1433,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1465,7 +1465,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
 		41005AA927CEF81A0065F323 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 41005AA827CEF81A0065F323 /* SwiftyJSON */; };
 		41005AAA27CEF8250065F323 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4114E1E827153FEE00388274 /* AVKit.framework */; };
 		41110A2825F9E79E008171D2 /* License.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41110A2725F9E79E008171D2 /* License.swift */; };
@@ -93,12 +94,12 @@
 		BA2727D02F22F1350027C4BD /* IconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727C82F22F1350027C4BD /* IconCache.swift */; };
 		BA2727D12F22F1350027C4BD /* MediaComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727C92F22F1350027C4BD /* MediaComponents.swift */; };
 		BA2727D22F22F1350027C4BD /* WallpaperPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727CB2F22F1350027C4BD /* WallpaperPicker.swift */; };
-		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
 		BA2728012F22F1350027C4BD /* BentoGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2728002F22F1350027C4BD /* BentoGridView.swift */; };
 		BA2728102F22F1350027C4BD /* DeploymentStepViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2728112F22F1350027C4BD /* DeploymentStepViews.swift */; };
 		BA2812002EBA161C00384582 /* InspectPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2811FF2EBA161C00384582 /* InspectPersistence.swift */; };
 		BA2812082EBA183A00384582 /* Preset6.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2812022EBA183A00384582 /* Preset6.swift */; };
 		BA3L0C122F9B3A00001367A5 /* LocalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3L0C112F9B3A00001367A5 /* LocalizationService.swift */; };
+		BA4DD5022F242A0000ABCDEF /* DateDisplayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */; };
 		BA56BA942EC5F41000055C7F /* InspectDynamicState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA912EC5F41000055C7F /* InspectDynamicState.swift */; };
 		BA56BA952EC5F41000055C7F /* PlistAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA932EC5F41000055C7F /* PlistAggregator.swift */; };
 		BA56BA962EC5F41000055C7F /* InspectStateMachines.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA922EC5F41000055C7F /* InspectStateMachines.swift */; };
@@ -113,6 +114,7 @@
 		BA7CA57E2F231310005A922A /* StatusContentBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5792F231310005A922A /* StatusContentBlocks.swift */; };
 		BA7CA57F2F231310005A922A /* MediaContentBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5782F231310005A922A /* MediaContentBlocks.swift */; };
 		BA7CA5812F231618005A922A /* IntroStepMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5802F231618005A922A /* IntroStepMonitorService.swift */; };
+		BA7TS0012F242B0000ABCDEF /* ThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */; };
 		BAB7C3CB2F39187B0033C0DC /* InspectBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB7C3CA2F39187B0033C0DC /* InspectBannerView.swift */; };
 		BAC04B282E2FB401006B0F89 /* AppInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B262E2FB401006B0F89 /* AppInspector.swift */; };
 		BAC04B292E2FB401006B0F89 /* InspectConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B272E2FB401006B0F89 /* InspectConstants.swift */; };
@@ -120,14 +122,12 @@
 		BAE4DDB3152893222E865858 /* DeferralMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE50F8E8766AAD7B36AC667 /* DeferralMenuView.swift */; };
 		BAEFDFE12E83FB310017CFC2 /* ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD62E83FB310017CFC2 /* ErrorHandling.swift */; };
 		BAEFDFE22E83FB310017CFC2 /* InstallationInfoPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDF2E83FB310017CFC2 /* InstallationInfoPopoverView.swift */; };
-		BA7TS0012F242B0000ABCDEF /* ThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */; };
 		BAEFDFE52E83FB310017CFC2 /* DialogCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDB2E83FB310017CFC2 /* DialogCache.swift */; };
 		BAEFDFE72E83FB310017CFC2 /* Preset2.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFCD2E83FB310017CFC2 /* Preset2.swift */; };
 		BAEFDFE82E83FB310017CFC2 /* InspectState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC82E83FB310017CFC2 /* InspectState.swift */; };
 		BAEFDFE92E83FB310017CFC2 /* InspectSizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC72E83FB310017CFC2 /* InspectSizes.swift */; };
 		BAEFDFEA2E83FB310017CFC2 /* InspectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC52E83FB310017CFC2 /* InspectConfig.swift */; };
 		BAEFDFEB2E83FB310017CFC2 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD92E83FB310017CFC2 /* Validation.swift */; };
-		BA4DD5022F242A0000ABCDEF /* DateDisplayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */; };
 		BAEFDFEE2E83FB310017CFC2 /* InspectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC92E83FB310017CFC2 /* InspectView.swift */; };
 		BAEFDFF02E83FB310017CFC2 /* InspectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDE2E83FB310017CFC2 /* InspectCoordinator.swift */; };
 		BAEFDFF12E83FB310017CFC2 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD52E83FB310017CFC2 /* Config.swift */; };
@@ -307,6 +307,7 @@
 		41FCF1F52EA9CFB000E3C47D /* CKMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKMessageView.swift; sourceTree = "<group>"; };
 		41FD45FD26C40366006976FC /* TimerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		41FD45FF26C8DC5D006976FC /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProceduralGradientView.swift; sourceTree = "<group>"; };
 		94072E482AFE931300B2A5C3 /* Font+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Additions.swift"; sourceTree = "<group>"; };
 		A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncedUpdater.swift; sourceTree = "<group>"; };
 		AA00000000000001AABBCC00 /* LogMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMonitorServiceTests.swift; sourceTree = "<group>"; };
@@ -321,12 +322,12 @@
 		BA2727C92F22F1350027C4BD /* MediaComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaComponents.swift; sourceTree = "<group>"; };
 		BA2727CA2F22F1350027C4BD /* StatusComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusComponents.swift; sourceTree = "<group>"; };
 		BA2727CB2F22F1350027C4BD /* WallpaperPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperPicker.swift; sourceTree = "<group>"; };
-		6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProceduralGradientView.swift; sourceTree = "<group>"; };
 		BA2728002F22F1350027C4BD /* BentoGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BentoGridView.swift; sourceTree = "<group>"; };
 		BA2728112F22F1350027C4BD /* DeploymentStepViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentStepViews.swift; sourceTree = "<group>"; };
 		BA2811FF2EBA161C00384582 /* InspectPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectPersistence.swift; sourceTree = "<group>"; };
 		BA2812022EBA183A00384582 /* Preset6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset6.swift; sourceTree = "<group>"; };
 		BA3L0C112F9B3A00001367A5 /* LocalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationService.swift; sourceTree = "<group>"; };
+		BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDisplayService.swift; sourceTree = "<group>"; };
 		BA56BA912EC5F41000055C7F /* InspectDynamicState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectDynamicState.swift; sourceTree = "<group>"; };
 		BA56BA922EC5F41000055C7F /* InspectStateMachines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectStateMachines.swift; sourceTree = "<group>"; };
 		BA56BA932EC5F41000055C7F /* PlistAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistAggregator.swift; sourceTree = "<group>"; };
@@ -341,6 +342,7 @@
 		BA7CA5792F231310005A922A /* StatusContentBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusContentBlocks.swift; sourceTree = "<group>"; };
 		BA7CA57A2F231310005A922A /* TableContentBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableContentBlocks.swift; sourceTree = "<group>"; };
 		BA7CA5802F231618005A922A /* IntroStepMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStepMonitorService.swift; sourceTree = "<group>"; };
+		BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
 		BAB7C3CA2F39187B0033C0DC /* InspectBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectBannerView.swift; sourceTree = "<group>"; };
 		BAC04B262E2FB401006B0F89 /* AppInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInspector.swift; sourceTree = "<group>"; };
 		BAC04B272E2FB401006B0F89 /* InspectConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectConstants.swift; sourceTree = "<group>"; };
@@ -359,13 +361,11 @@
 		BAEFDFD72E83FB310017CFC2 /* Monitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Monitoring.swift; sourceTree = "<group>"; };
 		BAEFDFD82E83FB310017CFC2 /* Progress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Progress.swift; sourceTree = "<group>"; };
 		BAEFDFD92E83FB310017CFC2 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
-		BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDisplayService.swift; sourceTree = "<group>"; };
 		BAEFDFDB2E83FB310017CFC2 /* DialogCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogCache.swift; sourceTree = "<group>"; };
 		BAEFDFDC2E83FB310017CFC2 /* FileMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMonitor.swift; sourceTree = "<group>"; };
 		BAEFDFDD2E83FB310017CFC2 /* ImageResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResolver.swift; sourceTree = "<group>"; };
 		BAEFDFDE2E83FB310017CFC2 /* InspectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectCoordinator.swift; sourceTree = "<group>"; };
 		BAEFDFDF2E83FB310017CFC2 /* InstallationInfoPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationInfoPopoverView.swift; sourceTree = "<group>"; };
-		BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
 		CA10102F3F10100000001A /* Preset4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset4.swift; sourceTree = "<group>"; };
 		CA10102F3F10100000002B /* SidebarNavigationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarNavigationModule.swift; sourceTree = "<group>"; };
 		CA22BB002F390600001367A5 /* PresetCommonHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetCommonHelpers.swift; sourceTree = "<group>"; };
@@ -1424,7 +1424,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -1433,7 +1433,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1456,7 +1456,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -1465,7 +1465,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1565,7 +1565,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1591,7 +1591,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1616,7 +1616,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1641,7 +1641,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		062741FDB5F456F760F3FC51 /* NotifierLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243992F6AB9F100F659CF /* NotifierLog.swift */; };
+		08AE83C187FDB862D626851D /* NotifierLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243992F6AB9F100F659CF /* NotifierLog.swift */; };
+		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
+		3183F3FFF17DBEECED93E72C /* NotifierNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439D2F6ABA1200F659CF /* NotifierNotifications.swift */; };
+		39A3F466EE23D697F2A106A5 /* Dialog Alert.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = C1D3259B83CF7CF206AC829A /* Dialog Alert.app */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		41005AA927CEF81A0065F323 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 41005AA827CEF81A0065F323 /* SwiftyJSON */; };
 		41005AAA27CEF8250065F323 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4114E1E827153FEE00388274 /* AVKit.framework */; };
 		41110A2825F9E79E008171D2 /* License.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41110A2725F9E79E008171D2 /* License.swift */; };
@@ -33,7 +38,6 @@
 		4154C2F125F76BDC00A3D373 /* dialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154C2F025F76BDC00A3D373 /* dialogTests.swift */; };
 		4154C2FC25F76BDC00A3D373 /* dialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154C2FB25F76BDC00A3D373 /* dialogUITests.swift */; };
 		415E1FCB27A2B0A000DE971B /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415E1FC927A2694B00DE971B /* ListView.swift */; };
-		416D81A42E7B6BEA000A53BD /* dialogcli in CopyFiles */ = {isa = PBXBuildFile; fileRef = 417DEF262E7ACCB600CAB132 /* dialogcli */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		416DED42261C5FE00049B6B5 /* FullscreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416DED41261C5FE00049B6B5 /* FullscreenView.swift */; };
 		417BD4362798FE48009AE34A /* DialogUpdatableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417BD4342798FE38009AE34A /* DialogUpdatableContent.swift */; };
 		417BD43827992EDB009AE34A /* TaskProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417BD43727992EDB009AE34A /* TaskProgressView.swift */; };
@@ -74,9 +78,17 @@
 		41FCF1F32EA8553700E3C47D /* CKJSONView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FCF1F22EA8553700E3C47D /* CKJSONView.swift */; };
 		41FCF1F62EA9CFB000E3C47D /* CKMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FCF1F52EA9CFB000E3C47D /* CKMessageView.swift */; };
 		4798E0B1BC024F44BF094D82 /* CarouselStepViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D7BDEBE83A4272AD647901 /* CarouselStepViews.swift */; };
+		49AC857FBDBF0DD01C008AD4 /* NotifierImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439B2F6AB9F200F659CF /* NotifierImages.swift */; };
+		4A9D058D6C2A35E2BE04193D /* NotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439E2F6ABA2100F659CF /* NotifierApp.swift */; };
 		539999E698B34FB983CBD679 /* ResolvedPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE10D7A467C4741B8ED3C59 /* ResolvedPalette.swift */; };
+		5543CCE7780E147E71384D94 /* NotifierSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439A2F6AB9F100F659CF /* NotifierSystem.swift */; };
+		57F9B9C1EF2A74E2A102169D /* (null) in Sources */ = {isa = PBXBuildFile; };
+		7FFEF40C74299E98B93387C0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 565B14745A83A0818EF73DE8 /* Cocoa.framework */; };
+		8767C98D590FE2B748834033 /* NotifierImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439B2F6AB9F200F659CF /* NotifierImages.swift */; };
+		8BEDF3E9EED8DB78C42C1918 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 565B14745A83A0818EF73DE8 /* Cocoa.framework */; };
 		927EC2B71BCB4E698795A084 /* DebouncedUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */; };
 		94072E492AFE931300B2A5C3 /* Font+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94072E482AFE931300B2A5C3 /* Font+Additions.swift */; };
+		A079957E24DA43793023165A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* BentoStepViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E1D0C9B8A7F6E5D4C3B2A1 /* BentoStepViews.swift */; };
 		A383B2EE203B064A4679B3F0 /* PresetPhaseViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2810AAF9ED2F802F95999029 /* PresetPhaseViews.swift */; };
 		AA00000000000001AABBCC01 /* LogMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000001AABBCC00 /* LogMonitorServiceTests.swift */; };
@@ -93,12 +105,12 @@
 		BA2727D02F22F1350027C4BD /* IconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727C82F22F1350027C4BD /* IconCache.swift */; };
 		BA2727D12F22F1350027C4BD /* MediaComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727C92F22F1350027C4BD /* MediaComponents.swift */; };
 		BA2727D22F22F1350027C4BD /* WallpaperPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2727CB2F22F1350027C4BD /* WallpaperPicker.swift */; };
-		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
 		BA2728012F22F1350027C4BD /* BentoGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2728002F22F1350027C4BD /* BentoGridView.swift */; };
 		BA2728102F22F1350027C4BD /* DeploymentStepViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2728112F22F1350027C4BD /* DeploymentStepViews.swift */; };
 		BA2812002EBA161C00384582 /* InspectPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2811FF2EBA161C00384582 /* InspectPersistence.swift */; };
 		BA2812082EBA183A00384582 /* Preset6.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2812022EBA183A00384582 /* Preset6.swift */; };
 		BA3L0C122F9B3A00001367A5 /* LocalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3L0C112F9B3A00001367A5 /* LocalizationService.swift */; };
+		BA4DD5022F242A0000ABCDEF /* DateDisplayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */; };
 		BA56BA942EC5F41000055C7F /* InspectDynamicState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA912EC5F41000055C7F /* InspectDynamicState.swift */; };
 		BA56BA952EC5F41000055C7F /* PlistAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA932EC5F41000055C7F /* PlistAggregator.swift */; };
 		BA56BA962EC5F41000055C7F /* InspectStateMachines.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA56BA922EC5F41000055C7F /* InspectStateMachines.swift */; };
@@ -113,6 +125,7 @@
 		BA7CA57E2F231310005A922A /* StatusContentBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5792F231310005A922A /* StatusContentBlocks.swift */; };
 		BA7CA57F2F231310005A922A /* MediaContentBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5782F231310005A922A /* MediaContentBlocks.swift */; };
 		BA7CA5812F231618005A922A /* IntroStepMonitorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CA5802F231618005A922A /* IntroStepMonitorService.swift */; };
+		BA7TS0012F242B0000ABCDEF /* ThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */; };
 		BAB7C3CB2F39187B0033C0DC /* InspectBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB7C3CA2F39187B0033C0DC /* InspectBannerView.swift */; };
 		BAC04B282E2FB401006B0F89 /* AppInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B262E2FB401006B0F89 /* AppInspector.swift */; };
 		BAC04B292E2FB401006B0F89 /* InspectConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC04B272E2FB401006B0F89 /* InspectConstants.swift */; };
@@ -120,14 +133,12 @@
 		BAE4DDB3152893222E865858 /* DeferralMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE50F8E8766AAD7B36AC667 /* DeferralMenuView.swift */; };
 		BAEFDFE12E83FB310017CFC2 /* ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD62E83FB310017CFC2 /* ErrorHandling.swift */; };
 		BAEFDFE22E83FB310017CFC2 /* InstallationInfoPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDF2E83FB310017CFC2 /* InstallationInfoPopoverView.swift */; };
-		BA7TS0012F242B0000ABCDEF /* ThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */; };
 		BAEFDFE52E83FB310017CFC2 /* DialogCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDB2E83FB310017CFC2 /* DialogCache.swift */; };
 		BAEFDFE72E83FB310017CFC2 /* Preset2.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFCD2E83FB310017CFC2 /* Preset2.swift */; };
 		BAEFDFE82E83FB310017CFC2 /* InspectState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC82E83FB310017CFC2 /* InspectState.swift */; };
 		BAEFDFE92E83FB310017CFC2 /* InspectSizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC72E83FB310017CFC2 /* InspectSizes.swift */; };
 		BAEFDFEA2E83FB310017CFC2 /* InspectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC52E83FB310017CFC2 /* InspectConfig.swift */; };
 		BAEFDFEB2E83FB310017CFC2 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD92E83FB310017CFC2 /* Validation.swift */; };
-		BA4DD5022F242A0000ABCDEF /* DateDisplayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */; };
 		BAEFDFEE2E83FB310017CFC2 /* InspectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFC92E83FB310017CFC2 /* InspectView.swift */; };
 		BAEFDFF02E83FB310017CFC2 /* InspectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFDE2E83FB310017CFC2 /* InspectCoordinator.swift */; };
 		BAEFDFF12E83FB310017CFC2 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEFDFD52E83FB310017CFC2 /* Config.swift */; };
@@ -150,6 +161,7 @@
 		CA56BA162F3904C000000006 /* ComplianceAggregatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA56BA062F3904C000000006 /* ComplianceAggregatorService.swift */; };
 		CA56BA172F3904C000000007 /* StarterTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA56BA072F3904C000000007 /* StarterTemplateService.swift */; };
 		CA71F1502F38D87900399EE3 /* OverrideDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA71F14F2F38D87900399EE3 /* OverrideDialogView.swift */; };
+		CB8F01908B3462200CEB696C /* Dialog Banner.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3DE18B81A96CFA5B6B75F255 /* Dialog Banner.app */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CC21904B2A7B994A00269525 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904A2A7B994A00269525 /* Preferences.swift */; };
 		CC21904E2A7BC3E000269525 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904D2A7BC3E000269525 /* Strings.swift */; };
 		CC2190502A7BC9FE00269525 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21904F2A7BC9FE00269525 /* Log.swift */; };
@@ -159,6 +171,7 @@
 		CC2190592A7BCDDD00269525 /* View+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2190582A7BCDDD00269525 /* View+Additions.swift */; };
 		CC21905D2A7BD7D300269525 /* AppVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21905C2A7BD7D300269525 /* AppVariables.swift */; };
 		CC21905F2A7BD7F200269525 /* CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21905E2A7BD7F200269525 /* CommandLineArguments.swift */; };
+		CC6AA24000B0ED567AB53585 /* NotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439E2F6ABA2100F659CF /* NotifierApp.swift */; };
 		CC72EBA22E1BE43400CF0DA1 /* dialogcli.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72EBA12E1BE43400CF0DA1 /* dialogcli.swift */; };
 		CC72EBA82E1BE48800CF0DA1 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = CC72EBA72E1BE48800CF0DA1 /* ArgumentParser */; };
 		CC7D43CF2B972976004B9E65 /* PresentationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D43CE2B972976004B9E65 /* PresentationView.swift */; };
@@ -166,12 +179,28 @@
 		CC9F8FEF2A5EC76400802A88 /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9F8FEE2A5EC76400802A88 /* ImageProcessing.swift */; };
 		CCB334702B2320F20079FB83 /* SolidColourView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3346F2B2320F20079FB83 /* SolidColourView.swift */; };
 		CCB35CB42BCFF4460041A701 /* SystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB35CB32BCFF4460041A701 /* SystemInfo.swift */; };
+		CCC243A22F6ABBA500F659CF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243A12F6ABBA500F659CF /* main.swift */; };
+		CCC243A32F6ABBA500F659CF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243A12F6ABBA500F659CF /* main.swift */; };
+		CCC243A52F6ABDEA00F659CF /* dialogcli in CopyFiles */ = {isa = PBXBuildFile; fileRef = 417DEF262E7ACCB600CAB132 /* dialogcli */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CCC243A72F6D451000F659CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4154C2E125F76BDC00A3D373 /* Assets.xcassets */; };
+		CCC243A92F6D452200F659CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4154C2E125F76BDC00A3D373 /* Assets.xcassets */; };
 		CCD8ACEC2A011C9500D98695 /* RadioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD8ACEB2A011C9500D98695 /* RadioView.swift */; };
 		CCE934AD2ACC29F60094BD06 /* TextFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE934AC2ACC29F60094BD06 /* TextFileView.swift */; };
 		CCF4305A2C07562D004DFB4D /* DebugOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF430592C07562D004DFB4D /* DebugOverlay.swift */; };
+		CE33CA7520E75A7DE06846D3 /* NotifierArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439C2F6AB9FD00F659CF /* NotifierArguments.swift */; };
+		E5EB15284862FB119AE272F6 /* NotifierNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439D2F6ABA1200F659CF /* NotifierNotifications.swift */; };
+		E60A5542B491A3CE58D101EF /* NotifierSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439A2F6AB9F100F659CF /* NotifierSystem.swift */; };
+		E6C55B960E864B6E5B688D82 /* NotifierArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439C2F6AB9FD00F659CF /* NotifierArguments.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		06D4AA8676B183EA684F7981 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4154C2D225F76BDB00A3D373 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 925B204C9A47C85216C4A35C;
+			remoteInfo = "DialogNotifier-Banner";
+		};
 		4154C2ED25F76BDC00A3D373 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4154C2D225F76BDB00A3D373 /* Project object */;
@@ -193,16 +222,24 @@
 			remoteGlobalIDString = 417DEF1B2E7ACCB600CAB132;
 			remoteInfo = dialogcli;
 		};
+		E5F4FD942189AB3410C37149 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4154C2D225F76BDB00A3D373 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95F390E6B6EB6F7FB24D25EC;
+			remoteInfo = "DialogNotifier-Alert";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		416D81A12E7B6BBF000A53BD /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 6;
+			dstPath = Contents/Helpers;
+			dstSubfolderSpec = 1;
 			files = (
-				416D81A42E7B6BEA000A53BD /* dialogcli in CopyFiles */,
+				39A3F466EE23D697F2A106A5 /* Dialog Alert.app in CopyFiles */,
+				CB8F01908B3462200CEB696C /* Dialog Banner.app in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -224,11 +261,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		CCC243A42F6ABDD100F659CF /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				CCC243A52F6ABDEA00F659CF /* dialogcli in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0CE10D7A467C4741B8ED3C59 /* ResolvedPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedPalette.swift; sourceTree = "<group>"; };
 		2810AAF9ED2F802F95999029 /* PresetPhaseViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetPhaseViews.swift; sourceTree = "<group>"; };
+		3DE18B81A96CFA5B6B75F255 /* Dialog Banner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Dialog Banner.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		41110A2725F9E79E008171D2 /* License.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = License.swift; sourceTree = "<group>"; };
 		41132F832F3CA018006BECA2 /* Markdown+Addittions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Markdown+Addittions.swift"; sourceTree = "<group>"; };
 		4114E1E827153FEE00388274 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
@@ -307,6 +355,8 @@
 		41FCF1F52EA9CFB000E3C47D /* CKMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKMessageView.swift; sourceTree = "<group>"; };
 		41FD45FD26C40366006976FC /* TimerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerView.swift; sourceTree = "<group>"; };
 		41FD45FF26C8DC5D006976FC /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		565B14745A83A0818EF73DE8 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProceduralGradientView.swift; sourceTree = "<group>"; };
 		94072E482AFE931300B2A5C3 /* Font+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Additions.swift"; sourceTree = "<group>"; };
 		A4F660819C6A4FBC8F1D8BAB /* DebouncedUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncedUpdater.swift; sourceTree = "<group>"; };
 		AA00000000000001AABBCC00 /* LogMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMonitorServiceTests.swift; sourceTree = "<group>"; };
@@ -321,12 +371,12 @@
 		BA2727C92F22F1350027C4BD /* MediaComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaComponents.swift; sourceTree = "<group>"; };
 		BA2727CA2F22F1350027C4BD /* StatusComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusComponents.swift; sourceTree = "<group>"; };
 		BA2727CB2F22F1350027C4BD /* WallpaperPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperPicker.swift; sourceTree = "<group>"; };
-		6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProceduralGradientView.swift; sourceTree = "<group>"; };
 		BA2728002F22F1350027C4BD /* BentoGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BentoGridView.swift; sourceTree = "<group>"; };
 		BA2728112F22F1350027C4BD /* DeploymentStepViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeploymentStepViews.swift; sourceTree = "<group>"; };
 		BA2811FF2EBA161C00384582 /* InspectPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectPersistence.swift; sourceTree = "<group>"; };
 		BA2812022EBA183A00384582 /* Preset6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset6.swift; sourceTree = "<group>"; };
 		BA3L0C112F9B3A00001367A5 /* LocalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationService.swift; sourceTree = "<group>"; };
+		BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDisplayService.swift; sourceTree = "<group>"; };
 		BA56BA912EC5F41000055C7F /* InspectDynamicState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectDynamicState.swift; sourceTree = "<group>"; };
 		BA56BA922EC5F41000055C7F /* InspectStateMachines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectStateMachines.swift; sourceTree = "<group>"; };
 		BA56BA932EC5F41000055C7F /* PlistAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistAggregator.swift; sourceTree = "<group>"; };
@@ -341,6 +391,7 @@
 		BA7CA5792F231310005A922A /* StatusContentBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusContentBlocks.swift; sourceTree = "<group>"; };
 		BA7CA57A2F231310005A922A /* TableContentBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableContentBlocks.swift; sourceTree = "<group>"; };
 		BA7CA5802F231618005A922A /* IntroStepMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroStepMonitorService.swift; sourceTree = "<group>"; };
+		BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
 		BAB7C3CA2F39187B0033C0DC /* InspectBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectBannerView.swift; sourceTree = "<group>"; };
 		BAC04B262E2FB401006B0F89 /* AppInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInspector.swift; sourceTree = "<group>"; };
 		BAC04B272E2FB401006B0F89 /* InspectConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectConstants.swift; sourceTree = "<group>"; };
@@ -359,13 +410,12 @@
 		BAEFDFD72E83FB310017CFC2 /* Monitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Monitoring.swift; sourceTree = "<group>"; };
 		BAEFDFD82E83FB310017CFC2 /* Progress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Progress.swift; sourceTree = "<group>"; };
 		BAEFDFD92E83FB310017CFC2 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
-		BA4DD5012F242A0000ABCDEF /* DateDisplayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDisplayService.swift; sourceTree = "<group>"; };
 		BAEFDFDB2E83FB310017CFC2 /* DialogCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogCache.swift; sourceTree = "<group>"; };
 		BAEFDFDC2E83FB310017CFC2 /* FileMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMonitor.swift; sourceTree = "<group>"; };
 		BAEFDFDD2E83FB310017CFC2 /* ImageResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResolver.swift; sourceTree = "<group>"; };
 		BAEFDFDE2E83FB310017CFC2 /* InspectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectCoordinator.swift; sourceTree = "<group>"; };
 		BAEFDFDF2E83FB310017CFC2 /* InstallationInfoPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationInfoPopoverView.swift; sourceTree = "<group>"; };
-		BA7TS0002F242B0000ABCDEF /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
+		C1D3259B83CF7CF206AC829A /* Dialog Alert.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Dialog Alert.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA10102F3F10100000001A /* Preset4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset4.swift; sourceTree = "<group>"; };
 		CA10102F3F10100000002B /* SidebarNavigationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarNavigationModule.swift; sourceTree = "<group>"; };
 		CA22BB002F390600001367A5 /* PresetCommonHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetCommonHelpers.swift; sourceTree = "<group>"; };
@@ -394,6 +444,15 @@
 		CC9F8FEE2A5EC76400802A88 /* ImageProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessing.swift; sourceTree = "<group>"; };
 		CCB3346F2B2320F20079FB83 /* SolidColourView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidColourView.swift; sourceTree = "<group>"; };
 		CCB35CB32BCFF4460041A701 /* SystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemInfo.swift; sourceTree = "<group>"; };
+		CCC243992F6AB9F100F659CF /* NotifierLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierLog.swift; sourceTree = "<group>"; };
+		CCC2439A2F6AB9F100F659CF /* NotifierSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierSystem.swift; sourceTree = "<group>"; };
+		CCC2439B2F6AB9F200F659CF /* NotifierImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierImages.swift; sourceTree = "<group>"; };
+		CCC2439C2F6AB9FD00F659CF /* NotifierArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierArguments.swift; sourceTree = "<group>"; };
+		CCC2439D2F6ABA1200F659CF /* NotifierNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierNotifications.swift; sourceTree = "<group>"; };
+		CCC2439E2F6ABA2100F659CF /* NotifierApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifierApp.swift; sourceTree = "<group>"; };
+		CCC2439F2F6ABA3200F659CF /* Info-Alert.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Alert.plist"; sourceTree = "<group>"; };
+		CCC243A02F6ABA3200F659CF /* Info-Banner.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Banner.plist"; sourceTree = "<group>"; };
+		CCC243A12F6ABBA500F659CF /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		CCD8ACEB2A011C9500D98695 /* RadioView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioView.swift; sourceTree = "<group>"; };
 		CCE934AC2ACC29F60094BD06 /* TextFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFileView.swift; sourceTree = "<group>"; };
 		CCF430592C07562D004DFB4D /* DebugOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOverlay.swift; sourceTree = "<group>"; };
@@ -405,6 +464,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		388A1DAE60C62215ADDC5626 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7FFEF40C74299E98B93387C0 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4154C2D725F76BDB00A3D373 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -439,6 +506,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		77C39FA06CD349FA36225F0F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BEDF3E9EED8DB78C42C1918 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CC72EB9C2E1BE43400CF0DA1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -454,6 +529,7 @@
 			isa = PBXGroup;
 			children = (
 				4114E1E827153FEE00388274 /* AVKit.framework */,
+				8A5A71D1A38488E0E2FCF220 /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -491,6 +567,7 @@
 				4154C2DB25F76BDB00A3D373 /* Products */,
 				4114E1E727153FEE00388274 /* Frameworks */,
 				417DEF162E7AA58700CAB132 /* Dialog copy2-Info.plist */,
+				CCC243982F6AB9DC00F659CF /* DialogNotifier */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -505,6 +582,8 @@
 				4154C2F725F76BDC00A3D373 /* dialogUITests.xctest */,
 				CC72EB9F2E1BE43400CF0DA1 /* dialog */,
 				417DEF262E7ACCB600CAB132 /* dialogcli */,
+				C1D3259B83CF7CF206AC829A /* Dialog Alert.app */,
+				3DE18B81A96CFA5B6B75F255 /* Dialog Banner.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -628,6 +707,14 @@
 			children = (
 			);
 			path = dialog;
+			sourceTree = "<group>";
+		};
+		8A5A71D1A38488E0E2FCF220 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				565B14745A83A0818EF73DE8 /* Cocoa.framework */,
+			);
+			name = "OS X";
 			sourceTree = "<group>";
 		};
 		BA2727CC2F22F1350027C4BD /* Components */ = {
@@ -843,6 +930,22 @@
 			path = dialogcli;
 			sourceTree = "<group>";
 		};
+		CCC243982F6AB9DC00F659CF /* DialogNotifier */ = {
+			isa = PBXGroup;
+			children = (
+				CCC243992F6AB9F100F659CF /* NotifierLog.swift */,
+				CCC2439A2F6AB9F100F659CF /* NotifierSystem.swift */,
+				CCC2439B2F6AB9F200F659CF /* NotifierImages.swift */,
+				CCC2439C2F6AB9FD00F659CF /* NotifierArguments.swift */,
+				CCC2439D2F6ABA1200F659CF /* NotifierNotifications.swift */,
+				CCC2439E2F6ABA2100F659CF /* NotifierApp.swift */,
+				CCC2439F2F6ABA3200F659CF /* Info-Alert.plist */,
+				CCC243A02F6ABA3200F659CF /* Info-Banner.plist */,
+				CCC243A12F6ABBA500F659CF /* main.swift */,
+			);
+			path = DialogNotifier;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -855,11 +958,14 @@
 				4154C2D825F76BDB00A3D373 /* Resources */,
 				CCFDE75A2A41B8B700009797 /* swiftlint */,
 				416D81A12E7B6BBF000A53BD /* CopyFiles */,
+				CCC243A42F6ABDD100F659CF /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				416D81A32E7B6BE0000A53BD /* PBXTargetDependency */,
+				A362002B3089A26BF15942C4 /* PBXTargetDependency */,
+				8032FF812680F75BF09FAB79 /* PBXTargetDependency */,
 			);
 			name = Dialog;
 			packageProductDependencies = (
@@ -927,6 +1033,40 @@
 			productName = dialogcli;
 			productReference = 417DEF262E7ACCB600CAB132 /* dialogcli */;
 			productType = "com.apple.product-type.tool";
+		};
+		925B204C9A47C85216C4A35C /* Dialog Banner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 168FDB895ADE244D75E02EF1 /* Build configuration list for PBXNativeTarget "Dialog Banner" */;
+			buildPhases = (
+				B87F8F160CFF3B951742213F /* Sources */,
+				CCC243A82F6D451700F659CF /* Resources */,
+				388A1DAE60C62215ADDC5626 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Dialog Banner";
+			productName = "DialogNotifier-Banner";
+			productReference = 3DE18B81A96CFA5B6B75F255 /* Dialog Banner.app */;
+			productType = "com.apple.product-type.application";
+		};
+		95F390E6B6EB6F7FB24D25EC /* Dialog Alert */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EDF1192423FB62106DC05D33 /* Build configuration list for PBXNativeTarget "Dialog Alert" */;
+			buildPhases = (
+				742A40D6BAFCAB9C7CCA5417 /* Sources */,
+				CCC243A62F6D450000F659CF /* Resources */,
+				77C39FA06CD349FA36225F0F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Dialog Alert";
+			productName = "DialogNotifier-Alert";
+			productReference = C1D3259B83CF7CF206AC829A /* Dialog Alert.app */;
+			productType = "com.apple.product-type.application";
 		};
 		CC72EB9E2E1BE43400CF0DA1 /* dialog */ = {
 			isa = PBXNativeTarget;
@@ -1007,6 +1147,8 @@
 				4154C2F625F76BDC00A3D373 /* dialogUITests */,
 				CC72EB9E2E1BE43400CF0DA1 /* dialog */,
 				417DEF1B2E7ACCB600CAB132 /* dialogcli */,
+				95F390E6B6EB6F7FB24D25EC /* Dialog Alert */,
+				925B204C9A47C85216C4A35C /* Dialog Banner */,
 			);
 		};
 /* End PBXProject section */
@@ -1032,6 +1174,22 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC243A62F6D450000F659CF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCC243A72F6D451000F659CF /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC243A82F6D451700F659CF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCC243A92F6D452200F659CF /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1239,6 +1397,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		742A40D6BAFCAB9C7CCA5417 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC6AA24000B0ED567AB53585 /* NotifierApp.swift in Sources */,
+				CCC243A32F6ABBA500F659CF /* main.swift in Sources */,
+				E6C55B960E864B6E5B688D82 /* NotifierArguments.swift in Sources */,
+				E5EB15284862FB119AE272F6 /* NotifierNotifications.swift in Sources */,
+				8767C98D590FE2B748834033 /* NotifierImages.swift in Sources */,
+				E60A5542B491A3CE58D101EF /* NotifierSystem.swift in Sources */,
+				08AE83C187FDB862D626851D /* NotifierLog.swift in Sources */,
+				57F9B9C1EF2A74E2A102169D /* (null) in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B87F8F160CFF3B951742213F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A9D058D6C2A35E2BE04193D /* NotifierApp.swift in Sources */,
+				CCC243A22F6ABBA500F659CF /* main.swift in Sources */,
+				CE33CA7520E75A7DE06846D3 /* NotifierArguments.swift in Sources */,
+				3183F3FFF17DBEECED93E72C /* NotifierNotifications.swift in Sources */,
+				49AC857FBDBF0DD01C008AD4 /* NotifierImages.swift in Sources */,
+				5543CCE7780E147E71384D94 /* NotifierSystem.swift in Sources */,
+				062741FDB5F456F760F3FC51 /* NotifierLog.swift in Sources */,
+				A079957E24DA43793023165A /* (null) in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CC72EB9B2E1BE43400CF0DA1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1265,6 +1453,16 @@
 			target = 417DEF1B2E7ACCB600CAB132 /* dialogcli */;
 			targetProxy = 416D81A22E7B6BE0000A53BD /* PBXContainerItemProxy */;
 		};
+		8032FF812680F75BF09FAB79 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 925B204C9A47C85216C4A35C /* Dialog Banner */;
+			targetProxy = 06D4AA8676B183EA684F7981 /* PBXContainerItemProxy */;
+		};
+		A362002B3089A26BF15942C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 95F390E6B6EB6F7FB24D25EC /* Dialog Alert */;
+			targetProxy = E5F4FD942189AB3410C37149 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -1286,6 +1484,62 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0C70F29594A34A7899DCF0F3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "DialogNotifier/Info-Alert.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 3.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog.notifier.alert;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		3F3FD2BDD1A1DA5B5F39EECB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "DialogNotifier/Info-Banner.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 3.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog.notifier.banner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		4154C2FE25F76BDC00A3D373 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1417,14 +1671,13 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = dialog/dialog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -1433,7 +1686,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1449,14 +1702,13 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = dialog/dialog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = dialog/Info.plist;
@@ -1465,7 +1717,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1561,11 +1813,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1587,11 +1838,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1612,11 +1862,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1637,11 +1886,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = D6G4X4D7C9;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1655,9 +1903,74 @@
 			};
 			name = Release;
 		};
+		E2F9312B6547F230D864466F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "DialogNotifier/Info-Banner.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 3.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog.notifier.banner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F8A8B0FEB5B47893664B7977 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "DialogNotifier/Info-Alert.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 3.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog.notifier.alert;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		168FDB895ADE244D75E02EF1 /* Build configuration list for PBXNativeTarget "Dialog Banner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F3FD2BDD1A1DA5B5F39EECB /* Release */,
+				E2F9312B6547F230D864466F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4154C2D525F76BDB00A3D373 /* Build configuration list for PBXProject "dialog" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1708,6 +2021,15 @@
 			buildConfigurations = (
 				CC72EBA32E1BE43400CF0DA1 /* Debug */,
 				CC72EBA42E1BE43400CF0DA1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EDF1192423FB62106DC05D33 /* Build configuration list for PBXNativeTarget "Dialog Alert" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C70F29594A34A7899DCF0F3 /* Release */,
+				F8A8B0FEB5B47893664B7977 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
 		062741FDB5F456F760F3FC51 /* NotifierLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243992F6AB9F100F659CF /* NotifierLog.swift */; };
 		08AE83C187FDB862D626851D /* NotifierLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC243992F6AB9F100F659CF /* NotifierLog.swift */; };
 		0940615EFBFC244436D747B3 /* ProceduralGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8E519DD87E7826F5EBAC1A /* ProceduralGradientView.swift */; };
@@ -175,8 +174,6 @@
 		CC21905D2A7BD7D300269525 /* AppVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21905C2A7BD7D300269525 /* AppVariables.swift */; };
 		CC21905F2A7BD7F200269525 /* CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC21905E2A7BD7F200269525 /* CommandLineArguments.swift */; };
 		CC6AA24000B0ED567AB53585 /* NotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC2439E2F6ABA2100F659CF /* NotifierApp.swift */; };
-		CC72EBA22E1BE43400CF0DA1 /* dialogcli.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC72EBA12E1BE43400CF0DA1 /* dialogcli.swift */; };
-		CC72EBA82E1BE48800CF0DA1 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = CC72EBA72E1BE48800CF0DA1 /* ArgumentParser */; };
 		CC7D43CF2B972976004B9E65 /* PresentationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D43CE2B972976004B9E65 /* PresentationView.swift */; };
 		CC7D44082B9C6FB5004B9E65 /* ImageFader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7D44072B9C6FB5004B9E65 /* ImageFader.swift */; };
 		CC9F8FEF2A5EC76400802A88 /* ImageProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9F8FEE2A5EC76400802A88 /* ImageProcessing.swift */; };
@@ -247,15 +244,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		417DEF222E7ACCB600CAB132 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
-		CC72EB9D2E1BE43400CF0DA1 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -442,7 +430,6 @@
 		CC21905C2A7BD7D300269525 /* AppVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVariables.swift; sourceTree = "<group>"; };
 		CC21905E2A7BD7F200269525 /* CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineArguments.swift; sourceTree = "<group>"; };
 		CC2190622A7DCA1A00269525 /* preinstall */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = preinstall; sourceTree = "<group>"; };
-		CC72EB9F2E1BE43400CF0DA1 /* dialog */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = dialog; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC72EBA12E1BE43400CF0DA1 /* dialogcli.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dialogcli.swift; sourceTree = "<group>"; };
 		CC7D43CE2B972976004B9E65 /* PresentationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationView.swift; sourceTree = "<group>"; };
 		CC7D44072B9C6FB5004B9E65 /* ImageFader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFader.swift; sourceTree = "<group>"; };
@@ -519,14 +506,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CC72EB9C2E1BE43400CF0DA1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CC72EBA82E1BE48800CF0DA1 /* ArgumentParser in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -585,7 +564,6 @@
 				4154C2DA25F76BDB00A3D373 /* Dialog.app */,
 				4154C2EC25F76BDC00A3D373 /* dialogTests.xctest */,
 				4154C2F725F76BDC00A3D373 /* dialogUITests.xctest */,
-				CC72EB9F2E1BE43400CF0DA1 /* dialog */,
 				417DEF262E7ACCB600CAB132 /* dialogcli */,
 				C1D3259B83CF7CF206AC829A /* Dialog Alert.app */,
 				3DE18B81A96CFA5B6B75F255 /* Dialog Banner.app */,
@@ -1075,26 +1053,6 @@
 			productReference = C1D3259B83CF7CF206AC829A /* Dialog Alert.app */;
 			productType = "com.apple.product-type.application";
 		};
-		CC72EB9E2E1BE43400CF0DA1 /* dialog */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CC72EBA52E1BE43400CF0DA1 /* Build configuration list for PBXNativeTarget "dialog" */;
-			buildPhases = (
-				CC72EB9B2E1BE43400CF0DA1 /* Sources */,
-				CC72EB9C2E1BE43400CF0DA1 /* Frameworks */,
-				CC72EB9D2E1BE43400CF0DA1 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = dialog;
-			packageProductDependencies = (
-				CC72EBA72E1BE48800CF0DA1 /* ArgumentParser */,
-			);
-			productName = dialogcli;
-			productReference = CC72EB9F2E1BE43400CF0DA1 /* dialog */;
-			productType = "com.apple.product-type.tool";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1115,9 +1073,6 @@
 					4154C2F625F76BDC00A3D373 = {
 						CreatedOnToolsVersion = 12.4;
 						TestTargetID = 4154C2D925F76BDB00A3D373;
-					};
-					CC72EB9E2E1BE43400CF0DA1 = {
-						CreatedOnToolsVersion = 15.4;
 					};
 				};
 			};
@@ -1152,7 +1107,6 @@
 				4154C2D925F76BDB00A3D373 /* Dialog */,
 				4154C2EB25F76BDC00A3D373 /* dialogTests */,
 				4154C2F625F76BDC00A3D373 /* dialogUITests */,
-				CC72EB9E2E1BE43400CF0DA1 /* dialog */,
 				417DEF1B2E7ACCB600CAB132 /* dialogcli */,
 				95F390E6B6EB6F7FB24D25EC /* Dialog Alert */,
 				925B204C9A47C85216C4A35C /* Dialog Banner */,
@@ -1436,14 +1390,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CC72EB9B2E1BE43400CF0DA1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CC72EBA22E1BE43400CF0DA1 /* dialogcli.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1499,12 +1445,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "DialogNotifier/Info-Alert.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1517,6 +1464,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1527,12 +1475,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "DialogNotifier/Info-Banner.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1545,6 +1494,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1680,12 +1630,13 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = dialog/dialog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1711,12 +1662,13 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = dialog/dialog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"dialog/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1738,9 +1690,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				INFOPLIST_FILE = dialogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1750,6 +1705,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dialog.app/Contents/MacOS/Dialog";
 			};
@@ -1759,9 +1715,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				INFOPLIST_FILE = dialogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1771,6 +1730,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dialog.app/Contents/MacOS/Dialog";
 			};
@@ -1779,9 +1739,12 @@
 		4154C30725F76BDC00A3D373 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				INFOPLIST_FILE = dialogUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1791,6 +1754,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = dialog;
 			};
@@ -1799,9 +1763,12 @@
 		4154C30825F76BDC00A3D373 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				INFOPLIST_FILE = dialogUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1811,6 +1778,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = dialog;
 			};
@@ -1822,9 +1790,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1847,9 +1816,10 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1865,65 +1835,19 @@
 			};
 			name = Release;
 		};
-		CC72EBA32E1BE43400CF0DA1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Automatic;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
-				ENABLE_APP_SANDBOX = NO;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialogcli;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		CC72EBA42E1BE43400CF0DA1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
-				CODE_SIGN_STYLE = Automatic;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
-				ENABLE_APP_SANDBOX = NO;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialogcli;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
 		E2F9312B6547F230D864466F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "DialogNotifier/Info-Banner.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1936,6 +1860,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -1946,12 +1871,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "DialogNotifier/Info-Alert.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1964,6 +1890,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -2021,15 +1948,6 @@
 			buildConfigurations = (
 				417DEF242E7ACCB600CAB132 /* Debug */,
 				417DEF252E7ACCB600CAB132 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CC72EBA52E1BE43400CF0DA1 /* Build configuration list for PBXNativeTarget "dialog" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CC72EBA32E1BE43400CF0DA1 /* Debug */,
-				CC72EBA42E1BE43400CF0DA1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2121,11 +2039,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 41BD41C32EA1FAF500DA7124 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
 			productName = SDWebImageSwiftUI;
-		};
-		CC72EBA72E1BE48800CF0DA1 /* ArgumentParser */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CC72EBA62E1BE48800CF0DA1 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
-			productName = ArgumentParser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -1441,7 +1441,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1473,7 +1473,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.csiro.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog.xcodeproj/xcshareddata/xcschemes/Dialog App Bundle.xcscheme
+++ b/dialog.xcodeproj/xcshareddata/xcschemes/Dialog App Bundle.xcscheme
@@ -77,7 +77,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--debug"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--displaylog /var/log/jamf.log"
@@ -145,10 +145,14 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--title &quot;xcode test window&quot;"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--builder"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--jsonfile /Users/rea094/Developer/testing/cards3.json"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -139,6 +139,7 @@ struct AppVariables {
     var titleFontName                   = ""
     var titleFontShadow                 = Bool(false)
     var titleFontAlignment              = ""
+    var titleFontOffset                 = CGFloat(0)
     var messageFontSize                 = CGFloat(20)
     var messageFontColour               = Color.primary
     var messageFontWeight               = Font.Weight.regular

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AppDefaults {
-    let cliversion                      = "2.6.0"
+    let cliversion                      = "3.0.1"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)

--- a/dialog/App Processing/AppVariables.swift
+++ b/dialog/App Processing/AppVariables.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct AppDefaults {
-    let cliversion                      = "3.0.1"
+    let cliversion                      = "3.1.0"
     let launchTime                      = Date.now
     // message default strings
     let titleDefault                    = String("default-title".localized)

--- a/dialog/App Processing/CardState.swift
+++ b/dialog/App Processing/CardState.swift
@@ -35,6 +35,10 @@ class CardState: ObservableObject {
     /// Key: card index, Value: dictionary of field name to value
     @Published var accumulatedInput: [Int: [String: Any]] = [:]
     
+    /// Global configuration from JSON (properties outside the cards array)
+    /// These serve as defaults that can be overridden by individual cards
+    var globalConfiguration: JSON = JSON()
+    
     /// Returns the current card, if any
     var currentCard: DialogCard? {
         guard isCardsMode, currentCardIndex >= 0, currentCardIndex < cards.count else {
@@ -76,6 +80,7 @@ class CardState: ObservableObject {
         guard json["cards"].exists(), json["cards"].type == .array else {
             isCardsMode = false
             cards = []
+            globalConfiguration = JSON()
             return false
         }
         
@@ -85,7 +90,18 @@ class CardState: ObservableObject {
         guard !cardsArray.isEmpty else {
             isCardsMode = false
             cards = []
+            globalConfiguration = JSON()
             return false
+        }
+        
+        // Extract global configuration (everything except the "cards" array)
+        // These properties serve as defaults for all cards
+        var globalJSON = json
+        globalJSON.dictionaryObject?.removeValue(forKey: "cards")
+        globalConfiguration = globalJSON
+        
+        if !globalConfiguration.isEmpty {
+            writeLog("Cards mode: loaded global configuration with \(globalConfiguration.dictionaryObject?.count ?? 0) properties")
         }
         
         // Parse cards with explicit id or inferred order
@@ -107,6 +123,22 @@ class CardState: ObservableObject {
         
         writeLog("Cards mode activated: loaded \(cards.count) cards")
         return true
+    }
+    
+    /// Get the merged configuration for a card (global defaults + card overrides)
+    /// - Parameter card: The card to get merged configuration for
+    /// - Returns: JSON with global properties merged with card-specific properties
+    func getMergedConfiguration(for card: DialogCard) -> JSON {
+        var merged = globalConfiguration
+        
+        // Card properties override global properties
+        if let cardDict = card.configuration.dictionaryObject {
+            for (key, value) in cardDict {
+                merged[key] = JSON(value)
+            }
+        }
+        
+        return merged
     }
     
     /// Move to the next card
@@ -166,12 +198,56 @@ class CardState: ObservableObject {
         return result
     }
     
+    /// Get stored input for a specific card (for restoration when navigating back)
+    /// - Parameter cardIndex: The card index to get input for
+    /// - Returns: Dictionary of field names to values, or nil if no input stored
+    func getStoredInput(for cardIndex: Int) -> [String: Any]? {
+        return accumulatedInput[cardIndex]
+    }
+    
+    /// Get all accumulated input as string values for variable substitution
+    /// This flattens complex values (like dropdown selections) to their string representation
+    /// - Returns: Dictionary suitable for use with processTextString tags
+    func getInputAsVariables() -> [String: String] {
+        var result: [String: String] = [:]
+        
+        // Iterate through all cards up to (but not including) current card
+        // This ensures we only substitute values from previous cards
+        for cardIndex in 0..<currentCardIndex {
+            if let cardInput = accumulatedInput[cardIndex] {
+                for (key, value) in cardInput {
+                    // Convert value to string for variable substitution
+                    if let stringValue = value as? String {
+                        result[key] = stringValue
+                    } else if let boolValue = value as? Bool {
+                        result[key] = boolValue ? "true" : "false"
+                    } else if let dictValue = value as? [String: Any] {
+                        // For dropdowns, use the selectedValue
+                        if let selectedValue = dictValue["selectedValue"] as? String {
+                            result[key] = selectedValue
+                        }
+                    } else {
+                        result[key] = String(describing: value)
+                    }
+                }
+            }
+        }
+        
+        return result
+    }
+    
+    /// Check if we have stored input for the current card (user navigated back)
+    var hasStoredInputForCurrentCard: Bool {
+        return accumulatedInput[currentCardIndex] != nil
+    }
+    
     /// Reset the card state
     func reset() {
         cards = []
         currentCardIndex = 0
         isCardsMode = false
         accumulatedInput = [:]
+        globalConfiguration = JSON()
     }
 }
 

--- a/dialog/App Processing/CardState.swift
+++ b/dialog/App Processing/CardState.swift
@@ -1,0 +1,179 @@
+//
+//  CardState.swift
+//  dialog
+//
+//  Created for swiftDialog cards workflow
+//
+
+import Foundation
+import SwiftyJSON
+
+/// Represents a single card configuration in a multi-card dialog workflow
+struct DialogCard: Identifiable {
+    var id: Int  // Explicit order of precedence
+    var configuration: JSON  // The card's dialog configuration
+    
+    init(id: Int, configuration: JSON) {
+        self.id = id
+        self.configuration = configuration
+    }
+}
+
+/// Manages the state of a multi-card dialog workflow
+class CardState: ObservableObject {
+    
+    /// All cards loaded from JSON configuration
+    @Published var cards: [DialogCard] = []
+    
+    /// Current card index (0-based)
+    @Published var currentCardIndex: Int = 0
+    
+    /// Whether cards mode is active
+    @Published var isCardsMode: Bool = false
+    
+    /// Accumulated user input from all cards
+    /// Key: card index, Value: dictionary of field name to value
+    @Published var accumulatedInput: [Int: [String: Any]] = [:]
+    
+    /// Returns the current card, if any
+    var currentCard: DialogCard? {
+        guard isCardsMode, currentCardIndex >= 0, currentCardIndex < cards.count else {
+            return nil
+        }
+        return cards[currentCardIndex]
+    }
+    
+    /// Returns true if there are more cards after the current one
+    var hasNextCard: Bool {
+        return isCardsMode && currentCardIndex < cards.count - 1
+    }
+    
+    /// Returns true if there are cards before the current one
+    var hasPreviousCard: Bool {
+        return isCardsMode && currentCardIndex > 0
+    }
+    
+    /// Returns true if on the last card
+    var isLastCard: Bool {
+        return isCardsMode && currentCardIndex == cards.count - 1
+    }
+    
+    /// Returns true if on the first card
+    var isFirstCard: Bool {
+        return currentCardIndex == 0
+    }
+    
+    /// Total number of cards
+    var totalCards: Int {
+        return cards.count
+    }
+    
+    /// Load cards from JSON
+    /// - Parameter json: The JSON object that may contain a "cards" array
+    /// - Returns: True if cards were loaded, false if no cards found (normal mode)
+    func loadCards(from json: JSON) -> Bool {
+        // Check if "cards" key exists and is an array
+        guard json["cards"].exists(), json["cards"].type == .array else {
+            isCardsMode = false
+            cards = []
+            return false
+        }
+        
+        let cardsArray = json["cards"].arrayValue
+        
+        // If no cards or empty array, operate normally
+        guard !cardsArray.isEmpty else {
+            isCardsMode = false
+            cards = []
+            return false
+        }
+        
+        // Parse cards with explicit id or inferred order
+        var loadedCards: [DialogCard] = []
+        
+        for (index, cardJSON) in cardsArray.enumerated() {
+            // Use explicit "id" if provided, otherwise use array position
+            let cardId = cardJSON["id"].int ?? index
+            loadedCards.append(DialogCard(id: cardId, configuration: cardJSON))
+        }
+        
+        // Sort cards by id for explicit ordering
+        loadedCards.sort { $0.id < $1.id }
+        
+        cards = loadedCards
+        currentCardIndex = 0
+        isCardsMode = true
+        accumulatedInput = [:]
+        
+        writeLog("Cards mode activated: loaded \(cards.count) cards")
+        return true
+    }
+    
+    /// Move to the next card
+    /// - Returns: True if moved to next card, false if already at last card
+    func nextCard() -> Bool {
+        guard hasNextCard else {
+            return false
+        }
+        currentCardIndex += 1
+        writeLog("Advanced to card \(currentCardIndex + 1) of \(totalCards)")
+        return true
+    }
+    
+    /// Move to the previous card
+    /// - Returns: True if moved to previous card, false if already at first card
+    func previousCard() -> Bool {
+        guard hasPreviousCard else {
+            return false
+        }
+        currentCardIndex -= 1
+        writeLog("Moved back to card \(currentCardIndex + 1) of \(totalCards)")
+        return true
+    }
+    
+    /// Store the current card's user input before transitioning
+    /// - Parameter input: Dictionary of field names to values
+    func storeCurrentCardInput(_ input: [String: Any]) {
+        accumulatedInput[currentCardIndex] = input
+        writeLog("Stored input for card \(currentCardIndex + 1)")
+    }
+    
+    /// Get all accumulated input as a flat dictionary
+    /// Later cards override earlier cards if same key exists
+    func getAllAccumulatedInput() -> [String: Any] {
+        var result: [String: Any] = [:]
+        
+        // Iterate through cards in order
+        for cardIndex in 0..<totalCards {
+            if let cardInput = accumulatedInput[cardIndex] {
+                for (key, value) in cardInput {
+                    result[key] = value
+                }
+            }
+        }
+        
+        return result
+    }
+    
+    /// Get accumulated input organized by card
+    func getAccumulatedInputByCard() -> [[String: Any]] {
+        var result: [[String: Any]] = []
+        
+        for cardIndex in 0..<totalCards {
+            result.append(accumulatedInput[cardIndex] ?? [:])
+        }
+        
+        return result
+    }
+    
+    /// Reset the card state
+    func reset() {
+        cards = []
+        currentCardIndex = 0
+        isCardsMode = false
+        accumulatedInput = [:]
+    }
+}
+
+// MARK: - Global card state instance
+var cardState = CardState()

--- a/dialog/CARDS_FEATURE_DOCUMENTATION.md
+++ b/dialog/CARDS_FEATURE_DOCUMENTATION.md
@@ -1,0 +1,610 @@
+# swiftDialog Cards Feature Documentation
+
+## Overview
+
+The **Cards** feature enables multi-step dialog workflows in swiftDialog, allowing you to create wizard-like user interfaces that guide users through multiple screens of input and information. Each card represents a separate screen with its own configuration, and users can navigate forward and backward through the cards.
+
+Cards are defined using JSON configuration files, making it easy to create complex, multi-step dialogs without writing code.
+
+## Key Features
+
+- **Multi-step workflows**: Break complex dialogs into manageable steps
+- **Navigation controls**: Automatic Next/Previous/Finish buttons
+- **Data persistence**: User input is preserved when navigating between cards
+- **Global defaults**: Define common settings once and override per card
+- **Variable substitution**: Reference values from previous cards using `{fieldname}` syntax
+- **Validation**: Required field validation before advancing
+- **Dynamic configuration**: Each card can have unique UI elements and settings
+- **Callbacks**: Execute shell scripts when advancing between cards
+
+## Basic Concepts
+
+### Cards Structure
+
+A cards-based dialog is defined in a JSON configuration file with the following structure:
+
+```json
+{
+  "cards": [
+    { "title": "Step 1", "message": "First screen..." },
+    { "title": "Step 2", "message": "Second screen..." },
+    { "title": "Step 3", "message": "Final screen..." }
+  ]
+}
+```
+
+### Global Configuration
+
+Properties defined at the root level (outside the `cards` array) serve as defaults for all cards. Individual cards can override these defaults:
+
+```json
+{
+  "icon": "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertNoteIcon.icns",
+  "button1text": "Continue",
+  "cards": [
+    { "title": "Step 1", "message": "Uses default icon" },
+    { "title": "Step 2", "icon": "SF=checkmark.circle", "message": "Custom icon" }
+  ]
+}
+```
+
+### Card Identification
+
+Cards are automatically ordered by their position in the array. You can optionally specify an explicit `id` for custom ordering:
+
+```json
+{
+  "cards": [
+    { "id": 0, "title": "First" },
+    { "id": 10, "title": "Second" },
+    { "id": 5, "title": "Third (will be displayed second)" }
+  ]
+}
+```
+
+## Navigation
+
+### Button Behavior
+
+In cards mode, the button behavior changes automatically:
+
+- **Button 1** (right side):
+  - Shows "Next" on cards 1 through n-1
+  - Shows "Finish" on the last card (or custom text via `button1text`)
+  - Validates required fields before advancing
+  
+- **Button 2** (left side):
+  - Hidden on the first card
+  - Shows "Previous" on cards 2 through n
+  - No validation when going backward
+
+### Navigation Flow
+
+```
+Card 1                Card 2                Card 3
+┌───────────┐        ┌───────────┐        ┌───────────┐
+│           │  Next  │           │  Next  │           │
+│           │───────>│           │───────>│           │
+│           │        │           │        │           │
+│   [Next]  │        │[Prev][Next]        │[Prev][Finish]
+└───────────┘        └───────────┘        └───────────┘
+                     <─────────            <─────────
+                      Previous             Previous
+```
+
+## Usage Examples
+
+### Example 1: Simple Three-Step Wizard
+
+```json
+{
+  "title": "Setup Wizard",
+  "icon": "SF=gearshape.2",
+  "button1text": "Continue",
+  "cards": [
+    {
+      "title": "Welcome",
+      "message": "Welcome to the setup wizard. Click Continue to begin."
+    },
+    {
+      "title": "Enter Information",
+      "message": "Please provide your details:",
+      "textfield": [
+        { "title": "Full Name", "required": true },
+        { "title": "Email Address", "required": true }
+      ]
+    },
+    {
+      "title": "Complete",
+      "message": "Setup is complete! Click Finish to close this wizard.",
+      "button1text": "Finish"
+    }
+  ]
+}
+```
+
+**Run it:**
+```bash
+dialog --jsonfile /path/to/config.json
+```
+
+### Example 2: Using Variable Substitution
+
+Variable substitution allows you to reference values from previous cards using `{fieldname}` syntax:
+
+```json
+{
+  "title": "User Registration",
+  "cards": [
+    {
+      "title": "Personal Information",
+      "message": "Step 1: Enter your details",
+      "textfield": [
+        { "title": "First Name", "required": true },
+        { "title": "Last Name", "required": true }
+      ]
+    },
+    {
+      "title": "Confirmation",
+      "message": "Hello {First Name} {Last Name}! Please confirm your information is correct.",
+      "infobox": "**Name:** {First Name} {Last Name}"
+    }
+  ]
+}
+```
+
+The `{First Name}` and `{Last Name}` placeholders in Card 2 will be replaced with the values entered in Card 1.
+
+### Example 3: Global Defaults with Overrides
+
+```json
+{
+  "icon": "SF=info.circle",
+  "width": 600,
+  "height": 400,
+  "cards": [
+    {
+      "title": "Introduction",
+      "message": "This card uses the default icon and size."
+    },
+    {
+      "title": "Custom Layout",
+      "icon": "SF=wrench.and.screwdriver",
+      "width": 800,
+      "height": 500,
+      "message": "This card has a custom icon and larger size."
+    },
+    {
+      "title": "Back to Normal",
+      "message": "This card reverts to default icon and size."
+    }
+  ]
+}
+```
+
+### Example 4: Data Collection Across Multiple Steps
+
+```json
+{
+  "title": "System Configuration",
+  "icon": "/System/Library/PreferencePanes/Appearance.prefPane/Contents/Resources/AppIcon.icns",
+  "cards": [
+    {
+      "title": "Network Settings",
+      "message": "Configure network preferences:",
+      "selectitems": [
+        {
+          "title": "Network Type",
+          "values": ["WiFi", "Ethernet", "VPN"],
+          "default": "WiFi"
+        }
+      ]
+    },
+    {
+      "title": "User Preferences",
+      "message": "Set user preferences:",
+      "checkbox": [
+        { "label": "Enable notifications", "checked": true },
+        { "label": "Auto-update", "checked": true },
+        { "label": "Send analytics", "checked": false }
+      ]
+    },
+    {
+      "title": "Summary",
+      "message": "Review your settings:",
+      "infobox": "**Network:** {Network Type}\\n\\n**Notifications:** {Enable notifications}\\n**Auto-update:** {Auto-update}\\n**Analytics:** {Send analytics}"
+    }
+  ]
+}
+```
+
+### Example 5: Progress Indicator with Cards
+
+```json
+{
+  "title": "Installation Wizard",
+  "cards": [
+    {
+      "title": "Preparing (1 of 3)",
+      "message": "Preparing installation...",
+      "progress": 100,
+      "progresstext": "Checking system requirements"
+    },
+    {
+      "title": "Installing (2 of 3)",
+      "message": "Installing software...",
+      "progress": 100,
+      "progresstext": "Copying files"
+    },
+    {
+      "title": "Complete (3 of 3)",
+      "message": "Installation complete!",
+      "icon": "SF=checkmark.circle.fill",
+      "progress": 100,
+      "progresstext": "Finished"
+    }
+  ]
+}
+```
+
+### Example 6: Required Fields Validation
+
+```json
+{
+  "title": "Registration Form",
+  "cards": [
+    {
+      "title": "Account Details",
+      "message": "All fields marked with * are required",
+      "textfield": [
+        { "title": "Username", "required": true, "prompt": "Enter username" },
+        { "title": "Password", "required": true, "secure": true },
+        { "title": "Confirm Password", "required": true, "secure": true }
+      ]
+    },
+    {
+      "title": "Contact Information",
+      "message": "Please provide at least one contact method",
+      "textfield": [
+        { "title": "Email", "required": true },
+        { "title": "Phone", "required": false }
+      ]
+    }
+  ]
+}
+```
+
+If users try to click Next without filling required fields, an error sheet will appear.
+
+## Advanced Features
+
+### Card-Specific Properties
+
+Any standard swiftDialog property can be used in a card. Common properties include:
+
+- **Layout**: `width`, `height`, `position`
+- **Content**: `title`, `message`, `icon`, `iconsize`
+- **Input**: `textfield`, `selectitems`, `checkbox`, `radio`
+- **Display**: `image`, `video`, `webcontent`, `listitem`
+- **Progress**: `progress`, `progresstext`
+- **Info**: `infobox`, `helpmessage`
+- **Styling**: `messagefont`, `alignment`, `bannerimage`
+
+### Input Field Naming
+
+For variable substitution to work correctly, input fields should have consistent naming:
+
+```json
+{
+  "textfield": [
+    { "title": "First Name" }  // Referenced as {First Name}
+  ],
+  "selectitems": [
+    { "title": "Department", "values": ["IT", "HR", "Sales"] }  // Referenced as {Department}
+  ]
+}
+```
+
+If a field has no explicit `title`, you can use a `name` property:
+
+```json
+{
+  "textfield": [
+    { "title": "Your Name", "name": "username" }  // Referenced as {username}
+  ]
+}
+```
+
+### Data Persistence
+
+User input is automatically saved when:
+- Clicking Next to advance to the next card
+- Clicking Previous to go back
+
+When users navigate back to a previous card, their input is restored.
+
+### Accessing Card Data
+
+When the user clicks Finish on the last card, all collected input is output to stdout in JSON format:
+
+```json
+{
+  "First Name": "John",
+  "Last Name": "Doe",
+  "Email Address": "john.doe@example.com",
+  "Department": "IT",
+  "Enable notifications": true
+}
+```
+
+### Callbacks on Advance
+
+Use the `--onadvance` option to execute a shell command when advancing between cards:
+
+```bash
+dialog --jsonfile config.json --onadvance "/path/to/script.sh"
+```
+
+The script receives:
+- Card index (0-based)
+- Card ID (if specified)
+- Current card input as JSON via stdin
+
+The script should exit with:
+- **Exit code 0**: Allow advancement
+- **Exit code non-zero**: Block advancement and show error message
+
+Example callback script:
+```bash
+#!/bin/bash
+# script.sh - Validate email format before advancing
+
+input=$(cat)
+email=$(echo "$input" | jq -r '.["Email Address"]')
+
+if [[ ! "$email" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}$ ]]; then
+    echo "Invalid email address format"
+    exit 1
+fi
+
+exit 0
+```
+
+## Best Practices
+
+### 1. Keep Cards Focused
+Each card should have a single, clear purpose. Don't overwhelm users with too many fields on one card.
+
+### 2. Use Descriptive Titles
+Card titles should clearly indicate what step the user is on:
+```json
+{ "title": "Step 1: Personal Information" }
+{ "title": "Step 2: Contact Details" }
+{ "title": "Step 3: Review & Confirm" }
+```
+
+### 3. Provide Context
+Use the message field to explain what the user needs to do:
+```json
+{
+  "title": "Account Setup",
+  "message": "Create your account by choosing a username and password. Your username must be at least 6 characters."
+}
+```
+
+### 4. Use Required Field Validation
+Mark essential fields as required to ensure data completeness:
+```json
+{ "title": "Email", "required": true }
+```
+
+### 5. Provide Summary Cards
+Include a final review card showing all collected information:
+```json
+{
+  "title": "Review Your Information",
+  "message": "Please verify everything is correct before proceeding.",
+  "infobox": "**Name:** {Full Name}\\n**Email:** {Email}\\n**Department:** {Department}"
+}
+```
+
+### 6. Consider Navigation Flow
+- Don't make the first card require extensive input - ease users in
+- Place the most important data collection early
+- Save confirmation/review for the final card
+
+### 7. Use Consistent Styling
+Define global defaults for consistent appearance:
+```json
+{
+  "icon": "SF=person.crop.circle",
+  "width": 700,
+  "height": 450,
+  "messagefont": "size=13",
+  "cards": [ /* ... */ ]
+}
+```
+
+## Limitations and Notes
+
+1. **Command File Updates**: When using cards mode with a command file, some dynamic updates may not work as expected. Cards mode is designed for input collection rather than dynamic status updates.
+
+2. **Button Customization**: Button 1 and Button 2 behavior is controlled by cards mode and cannot be fully customized while in cards mode.
+
+3. **Exit Codes**: In cards mode, the dialog only exits when:
+   - User clicks Finish on the last card (exit code 0)
+   - User cancels (exit code varies)
+   - Validation fails and user chooses to cancel
+
+4. **Variable Scope**: Variables from previous cards are only available in subsequent cards, not in earlier cards. Variable substitution is one-directional.
+
+5. **Field Naming**: For proper variable substitution, use alphanumeric characters and spaces in field titles. Special characters may cause issues.
+
+## Troubleshooting
+
+### Cards Not Appearing
+- Check JSON syntax with `jsonlint` or similar tool
+- Ensure the `cards` array is at the root level
+- Verify at least one card is defined
+
+### Variables Not Substituting
+- Ensure field names match exactly (case-sensitive)
+- Check that variable references use curly braces: `{fieldname}`
+- Verify the referenced field was on a previous card, not the current or future card
+
+### Validation Not Working
+- Confirm `"required": true` is set on fields
+- Check that field has a `title` or `name` property
+- Review debug logs with `--debug` flag
+
+### Previous Button Not Showing
+- Verify you're not on the first card (Previous is hidden on card 1)
+- Check that cards mode is actually enabled (cards array exists)
+
+## Complete Example: Employee Onboarding Wizard
+
+```json
+{
+  "title": "Employee Onboarding",
+  "icon": "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/UserIcon.icns",
+  "width": 750,
+  "height": 500,
+  "button1text": "Continue",
+  "cards": [
+    {
+      "title": "Welcome to the Company!",
+      "message": "## Welcome Aboard!\\n\\nThis wizard will guide you through the onboarding process.\\n\\nClick Continue to get started.",
+      "icon": "SF=hands.clap.fill",
+      "iconsize": 120
+    },
+    {
+      "title": "Personal Information",
+      "message": "Please provide your personal details (all fields required):",
+      "textfield": [
+        { "title": "First Name", "required": true },
+        { "title": "Last Name", "required": true },
+        { "title": "Employee ID", "required": true },
+        { "title": "Work Email", "required": true, "prompt": "name@company.com" }
+      ]
+    },
+    {
+      "title": "Department Assignment",
+      "message": "Select your department and role:",
+      "selectitems": [
+        {
+          "title": "Department",
+          "values": ["Engineering", "Marketing", "Sales", "HR", "Finance"],
+          "default": "Engineering"
+        },
+        {
+          "title": "Role",
+          "values": ["Manager", "Senior", "Mid-level", "Junior"],
+          "default": "Mid-level"
+        }
+      ]
+    },
+    {
+      "title": "System Preferences",
+      "message": "Configure your system preferences:",
+      "checkbox": [
+        { "label": "Enable email notifications", "checked": true },
+        { "label": "Join company Slack", "checked": true },
+        { "label": "Subscribe to company newsletter", "checked": true },
+        { "label": "Opt-in to mentorship program", "checked": false }
+      ]
+    },
+    {
+      "title": "Review & Confirm",
+      "message": "Please review your information before completing the onboarding process:",
+      "icon": "SF=checkmark.circle",
+      "infobox": "**Name:** {First Name} {Last Name}\\n**Employee ID:** {Employee ID}\\n**Email:** {Work Email}\\n\\n**Department:** {Department}\\n**Role:** {Role}\\n\\n**Email Notifications:** {Enable email notifications}\\n**Slack:** {Join company Slack}\\n**Newsletter:** {Subscribe to company newsletter}\\n**Mentorship:** {Opt-in to mentorship program}",
+      "button1text": "Complete Onboarding"
+    }
+  ]
+}
+```
+
+Save this as `onboarding.json` and run:
+```bash
+dialog --jsonfile onboarding.json
+```
+
+## Integration Example: Shell Script
+
+Here's a complete shell script example that uses cards mode and processes the output:
+
+```bash
+#!/bin/bash
+
+# onboarding.sh - Employee onboarding with swiftDialog cards
+
+DIALOG="/usr/local/bin/dialog"
+CONFIG="/tmp/onboarding_config.json"
+
+# Create the JSON configuration
+cat > "$CONFIG" << 'EOF'
+{
+  "title": "Employee Onboarding",
+  "icon": "SF=person.crop.circle.badge.checkmark",
+  "width": 700,
+  "height": 450,
+  "cards": [
+    {
+      "title": "Welcome",
+      "message": "Welcome to Company XYZ! This wizard will set up your account."
+    },
+    {
+      "title": "Enter Details",
+      "message": "Please provide your information:",
+      "textfield": [
+        { "title": "Full Name", "required": true },
+        { "title": "Email", "required": true }
+      ]
+    },
+    {
+      "title": "Complete",
+      "message": "Onboarding complete for {Full Name}!",
+      "infobox": "We'll send a confirmation to {Email}"
+    }
+  ]
+}
+EOF
+
+# Run dialog and capture output
+if output=$("$DIALOG" --jsonfile "$CONFIG" 2>&1); then
+    echo "Onboarding completed successfully!"
+    echo "Collected data:"
+    echo "$output" | jq .
+    
+    # Extract specific fields
+    full_name=$(echo "$output" | jq -r '.["Full Name"]')
+    email=$(echo "$output" | jq -r '.Email')
+    
+    echo "Processing onboarding for $full_name ($email)..."
+    
+    # Add your custom logic here
+    # - Create user account
+    # - Send welcome email
+    # - Configure systems
+    
+else
+    echo "Onboarding was cancelled or failed"
+    exit 1
+fi
+
+# Cleanup
+rm -f "$CONFIG"
+```
+
+## Summary
+
+The Cards feature in swiftDialog provides a powerful way to create multi-step, wizard-like interfaces using simple JSON configuration. Key benefits include:
+
+- **Simplified complex workflows** - Break down complicated processes into manageable steps
+- **Built-in navigation** - Automatic Next/Previous/Finish buttons
+- **Data collection** - Easily gather and validate user input across multiple screens
+- **Flexible configuration** - Use global defaults and per-card overrides
+- **Variable substitution** - Reference previous card values in later cards
+- **No coding required** - Define everything in JSON
+
+For more information on individual swiftDialog options and parameters, refer to the main swiftDialog documentation or use `dialog --help`.

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -106,6 +106,7 @@ struct CommandLineArguments {
     var playSound                = CommandlineArgument(long: "sound")
     var dockIcon                 = CommandlineArgument(long: "dockicon")
     var dockBadge                = CommandlineArgument(long: "dockiconbadge")
+    var onAdvance                = CommandlineArgument(long: "onadvance")
 
     // command line options that take no additional parameters
     var button1Disabled          = CommandlineArgument(long: "button1disabled", isbool: true)
@@ -362,6 +363,7 @@ extension CommandLineArguments {
                     case "showDockIcon": self.showDockIcon = argument
                     case "dockIcon": self.dockIcon = argument
                     case "dockBadge": self.dockBadge = argument
+                    case "onAdvance": self.onAdvance = argument
                     default: break
                     }
                 }
@@ -493,6 +495,7 @@ extension CommandLineArguments {
                 case "showDockIcon": self.showDockIcon = argument
                 case "dockIcon": self.dockIcon = argument
                 case "dockBadge": self.dockBadge = argument
+                case "onAdvance": self.onAdvance = argument
                 default: break
                 }
             }

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -368,4 +368,134 @@ extension CommandLineArguments {
             }
         }
     }
+    
+    /// Reset all arguments to their default values
+    /// This creates a fresh CommandLineArguments struct and copies the default values
+    public mutating func resetToDefaults() {
+        let defaults = CommandLineArguments()
+        let mirror = Mirror(reflecting: defaults)
+        
+        for child in mirror.children {
+            if let argument = child.value as? CommandlineArgument, let label = child.label {
+                // Reset each argument to its default state
+                switch label {
+                case "titleOption": self.titleOption = argument
+                case "subTitleOption": self.subTitleOption = argument
+                case "messageOption": self.messageOption = argument
+                case "dialogStyle": self.dialogStyle = argument
+                case "messageAlignment": self.messageAlignment = argument
+                case "helpAlignment": self.helpAlignment = argument
+                case "messageAlignmentOld": self.messageAlignmentOld = argument
+                case "messageVerticalAlignment": self.messageVerticalAlignment = argument
+                case "helpMessage": self.helpMessage = argument
+                case "helpImage": self.helpImage = argument
+                case "helpSheetButton": self.helpSheetButton = argument
+                case "iconOption": self.iconOption = argument
+                case "iconSize": self.iconSize = argument
+                case "iconAlpha": self.iconAlpha = argument
+                case "iconAccessabilityLabel": self.iconAccessabilityLabel = argument
+                case "overlayIconOption": self.overlayIconOption = argument
+                case "bannerImage": self.bannerImage = argument
+                case "bannerTitle": self.bannerTitle = argument
+                case "bannerText": self.bannerText = argument
+                case "bannerHeight": self.bannerHeight = argument
+                case "button1TextOption": self.button1TextOption = argument
+                case "button1ActionOption": self.button1ActionOption = argument
+                case "button1Symbol": self.button1Symbol = argument
+                case "button1ShellActionOption": self.button1ShellActionOption = argument
+                case "button2TextOption": self.button2TextOption = argument
+                case "button2ActionOption": self.button2ActionOption = argument
+                case "button2Symbol": self.button2Symbol = argument
+                case "buttonInfoTextOption": self.buttonInfoTextOption = argument
+                case "buttonInfoActionOption": self.buttonInfoActionOption = argument
+                case "buttonInfoSymbol": self.buttonInfoSymbol = argument
+                case "buttonStyle": self.buttonStyle = argument
+                case "buttonSize": self.buttonSize = argument
+                case "buttonTextSize": self.buttonTextSize = argument
+                case "dropdownTitle": self.dropdownTitle = argument
+                case "dropdownValues": self.dropdownValues = argument
+                case "dropdownDefault": self.dropdownDefault = argument
+                case "dropdownStyle": self.dropdownStyle = argument
+                case "titleFont": self.titleFont = argument
+                case "messageFont": self.messageFont = argument
+                case "textField": self.textField = argument
+                case "textFieldLiveValidation": self.textFieldLiveValidation = argument
+                case "checkbox": self.checkbox = argument
+                case "checkboxStyle": self.checkboxStyle = argument
+                case "timerBar": self.timerBar = argument
+                case "progressBar": self.progressBar = argument
+                case "progressText": self.progressText = argument
+                case "progressTextAlignment": self.progressTextAlignment = argument
+                case "mainImage": self.mainImage = argument
+                case "mainImageCaption": self.mainImageCaption = argument
+                case "windowWidth": self.windowWidth = argument
+                case "windowHeight": self.windowHeight = argument
+                case "watermarkImage": self.watermarkImage = argument
+                case "watermarkAlpha": self.watermarkAlpha = argument
+                case "watermarkPosition": self.watermarkPosition = argument
+                case "watermarkFill": self.watermarkFill = argument
+                case "watermarkScale": self.watermarkScale = argument
+                case "position": self.position = argument
+                case "positionOffset": self.positionOffset = argument
+                case "video": self.video = argument
+                case "videoCaption": self.videoCaption = argument
+                case "debug": self.debug = argument
+                case "listItem": self.listItem = argument
+                case "listStyle": self.listStyle = argument
+                case "listSelectionEnabled": self.listSelectionEnabled = argument
+                case "infoText": self.infoText = argument
+                case "infoBox": self.infoBox = argument
+                case "quitKey": self.quitKey = argument
+                case "webcontent": self.webcontent = argument
+                case "logFileToTail": self.logFileToTail = argument
+                case "logFileHistory": self.logFileHistory = argument
+                case "preferredViewOrder": self.preferredViewOrder = argument
+                case "preferredAppearance": self.preferredAppearance = argument
+                case "playSound": self.playSound = argument
+                // Boolean flags
+                case "button1Disabled": self.button1Disabled = argument
+                case "button2Disabled": self.button2Disabled = argument
+                case "button2Option": self.button2Option = argument
+                case "infoButtonOption": self.infoButtonOption = argument
+                case "hideIcon": self.hideIcon = argument
+                case "centreIcon": self.centreIcon = argument
+                case "centreIconSE": self.centreIconSE = argument
+                case "warningIcon": self.warningIcon = argument
+                case "infoIcon": self.infoIcon = argument
+                case "cautionIcon": self.cautionIcon = argument
+                case "hideTimerBar": self.hideTimerBar = argument
+                case "hideTimer": self.hideTimer = argument
+                case "autoPlay": self.autoPlay = argument
+                case "blurScreen": self.blurScreen = argument
+                case "notification": self.notification = argument
+                case "movableWindow": self.movableWindow = argument
+                case "forceOnTop": self.forceOnTop = argument
+                case "smallWindow": self.smallWindow = argument
+                case "bigWindow": self.bigWindow = argument
+                case "fullScreenWindow": self.fullScreenWindow = argument
+                case "quitOnInfo": self.quitOnInfo = argument
+                case "listFonts": self.listFonts = argument
+                case "jsonOutPut": self.jsonOutPut = argument
+                case "ignoreDND": self.ignoreDND = argument
+                case "miniMode": self.miniMode = argument
+                case "eulaMode": self.eulaMode = argument
+                case "presentationMode": self.presentationMode = argument
+                case "windowButtonsEnabled": self.windowButtonsEnabled = argument
+                case "windowResizable": self.windowResizable = argument
+                case "showOnAllScreens": self.showOnAllScreens = argument
+                case "notificationGoPing": self.notificationGoPing = argument
+                case "loginWindow": self.loginWindow = argument
+                case "hideDefaultKeyboardAction": self.hideDefaultKeyboardAction = argument
+                case "alwaysReturnUserInput": self.alwaysReturnUserInput = argument
+                case "removeNotification": self.removeNotification = argument
+                case "showSoundControls": self.showSoundControls = argument
+                case "hideOtherApps": self.hideOtherApps = argument
+                case "showDockIcon": self.showDockIcon = argument
+                case "dockIcon": self.dockIcon = argument
+                case "dockBadge": self.dockBadge = argument
+                default: break
+                }
+            }
+        }
+    }
 }

--- a/dialog/Command Line/CommandLineArguments.swift
+++ b/dialog/Command Line/CommandLineArguments.swift
@@ -19,6 +19,7 @@ struct CommandlineArgument {
     var present: Bool = false
     var isbool: Bool = false
     var overrideDefaultIfNill = false
+    var hidden: Bool = false
 }
 
 struct CommandLineArguments {
@@ -45,7 +46,7 @@ struct CommandLineArguments {
     var bannerHeight             = CommandlineArgument(long: "bannerheight")
     var button1TextOption        = CommandlineArgument(long: "button1text", defaultValue: appDefaults.button1Default, overrideDefaultIfNill: true)
     var button1ActionOption      = CommandlineArgument(long: "button1action")
-    var button1ShellActionOption = CommandlineArgument(long: "button1shellaction",short: "")
+    var button1ShellActionOption = CommandlineArgument(long: "button1shellaction",short: "", hidden: true)
     var button1Symbol            = CommandlineArgument(long: "button1symbol")
     var button2TextOption        = CommandlineArgument(long: "button2text", defaultValue: appDefaults.button2Default)
     var button2ActionOption      = CommandlineArgument(long: "button2action")
@@ -102,7 +103,7 @@ struct CommandLineArguments {
     var preferredAppearance      = CommandlineArgument(long: "appearance")
     var setAppIcon               = CommandlineArgument(long: "seticon")
     var notificationIdentifier   = CommandlineArgument(long: "identifier", short: "id")
-    var callingPid               = CommandlineArgument(long: "pid", defaultValue: 0)
+    var callingPid               = CommandlineArgument(long: "pid", defaultValue: 0, hidden: true)
     var playSound                = CommandlineArgument(long: "sound")
     var dockIcon                 = CommandlineArgument(long: "dockicon")
     var dockBadge                = CommandlineArgument(long: "dockiconbadge")
@@ -116,10 +117,10 @@ struct CommandLineArguments {
     var getVersion               = CommandlineArgument(long: "version", short: "v", isbool: true)
     var hideIcon                 = CommandlineArgument(long: "hideicon", short: "h", isbool: true)
     var centreIcon               = CommandlineArgument(long: "centreicon", isbool: true)
-    var centreIconSE             = CommandlineArgument(long: "centericon", isbool: true) // the other way of spelling
+    var centreIconSE             = CommandlineArgument(long: "centericon", isbool: true, hidden: true) // the other way of spelling
     var helpOption               = CommandlineArgument(long: "help", isbool: true)
     var demoOption               = CommandlineArgument(long: "demo", isbool: true)
-    var buyCoffee                = CommandlineArgument(long: "coffee", short: "☕️", isbool: true)
+    var buyCoffee                = CommandlineArgument(long: "coffee", short: "☕️", isbool: true, hidden: true)
     var licence                  = CommandlineArgument(long: "licence", short: "l", isbool: true)
     var warningIcon              = CommandlineArgument(long: "warningicon", isbool: true) // Deprecated
     var infoIcon                 = CommandlineArgument(long: "infoicon", isbool: true) // Deprecated

--- a/dialog/Command Line/HelpText.swift
+++ b/dialog/Command Line/HelpText.swift
@@ -13,18 +13,20 @@ struct SDHelp {
     public func printHelpShort() {
         writeLog("Printing short help")
         print("swiftDialog v\(getVersionString())")
-        print("©2024 Bart Reardon\n")
+        print("© CSIRO and Bart Reardon\n")
         print("\n use --help <option> for more details\n")
         let mirror = Mirror(reflecting: argument)
         for child in mirror.children {
             if let arg = child.value as? CommandlineArgument {
-                var helpArgs = " --\(arg.long) \(arg.helpUsage)"
-                if arg.short != "" {
-                    helpArgs = " -\(arg.short), \(helpArgs)"
-                }
-                if arg.helpShort != "" {
-                    print("  \(helpArgs)\n")
-                    print("\t\(arg.helpShort)\n")
+                if !arg.hidden {
+                    var helpArgs = " --\(arg.long) \(arg.helpUsage)"
+                    if arg.short != "" {
+                        helpArgs = " -\(arg.short), \(helpArgs)"
+                    }
+                    if arg.helpShort != "" {
+                        print("  \(helpArgs)\n")
+                        print("\t\(arg.helpShort)\n")
+                    }
                 }
             }
         }
@@ -1245,6 +1247,169 @@ struct SDHelp {
         Prints list of command line options and any arguments
 
         Use with an option name as the argument to get detailed information about that argument
+"""
+
+        // MARK: - Previously undocumented options — help text stubs added for release/3.1.0
+
+        argument.onAdvance.helpShort = "Execute a shell command when advancing between cards"
+        argument.onAdvance.helpUsage = "<command>"
+        argument.onAdvance.helpLong = """
+        When using cards mode, specifies a shell command to execute each time the user
+        advances to the next card. The command receives a JSON payload via stdin containing
+        the current card index, card ID and user input from the current card.
+
+        JSON payload format:
+            {
+                "cardIndex": <int>,
+                "cardId": "<string>",
+                "input": { <user input key/value pairs> }
+            }
+
+        If the command exits with code 0, advancement proceeds.
+        If the command exits with a non-zero code, advancement is blocked and the
+        stderr (or stdout) output is displayed to the user as an error message.
+
+        Example:
+            --\(argument.onAdvance.long) "/path/to/validation_script.sh"
+"""
+
+        argument.helpAlignment.helpShort = "Set the help message text alignment"
+        argument.helpAlignment.helpUsage = "[left | centre | center | right]"
+        argument.helpAlignment.helpLong = """
+        Sets the text alignment of the help sheet message content.
+        Default alignment matches the message alignment setting.
+"""
+
+        argument.helpSheetButton.helpShort = "Set the help sheet dismiss button text"
+        argument.helpSheetButton.helpUsage = "<text>"
+        argument.helpSheetButton.helpLong = """
+        Sets the text displayed on the button used to dismiss the help sheet.
+        Default is "OK".
+"""
+
+        argument.iconAccessabilityLabel.helpShort = "Set the accessibility label for the dialog icon"
+        argument.iconAccessabilityLabel.helpUsage = "<text>"
+        argument.iconAccessabilityLabel.helpLong = """
+        Provides alternative text for the dialog icon, used by screen readers
+        and other assistive technologies.
+        Default is "Dialog Icon".
+"""
+
+        argument.bannerHeight.helpShort = "Set the banner image height"
+        argument.bannerHeight.helpUsage = "<number>"
+        argument.bannerHeight.helpLong = """
+        Sets the height of the banner image area in points.
+        Use in conjunction with --\(argument.bannerImage.long).
+"""
+
+
+        argument.button1ShellActionOption.helpShort = "Set a shell command to execute when Button1 is clicked"
+        argument.button1ShellActionOption.helpUsage = "<command>"
+        argument.button1ShellActionOption.helpLong = """
+        Specifies a shell command to execute when button 1 is clicked,
+        instead of opening a URL as with --\(argument.button1ActionOption.long).
+
+        The command is executed via /bin/zsh.
+        Return code when actioned is 0.
+"""
+
+        
+        argument.dropdownStyle.helpShort = "Set the presentation style for select lists"
+        argument.dropdownStyle.helpUsage = "[list | radio | searchable | multiselect]"
+        argument.dropdownStyle.helpLong = """
+        Controls the display style of all dropdown/select list items.
+        This applies globally; per-list styles can also be set via modifiers
+        on --\(argument.dropdownTitle.long).
+
+        Default is "list".
+"""
+
+        argument.setAppIcon.helpShort = "Set the swiftDialog application icon"
+        argument.setAppIcon.helpUsage = "<file>"
+        argument.setAppIcon.helpLong = """
+        Sets the swiftDialog application icon to the specified image.
+        Also updates the icons of any embedded notification helper apps.
+        swiftDialog will exit immediately after setting the icon.
+"""
+
+        argument.callingPid.helpShort = "Monitor a parent process by PID"
+        argument.callingPid.helpUsage = "<int>"
+        argument.callingPid.helpLong = """
+        Monitors the specified process ID. If the process terminates,
+        swiftDialog will automatically exit with code 40.
+
+        This is used to tie the dialog lifecycle to a calling process.
+"""
+
+        argument.progressTextAlignment.helpShort = "Set progress text alignment"
+        argument.progressTextAlignment.helpUsage = "[left | right]"
+        argument.progressTextAlignment.helpLong = """
+        Sets the horizontal alignment of the progress text displayed underneath the progress bar.
+        Default is centred.
+"""
+
+        argument.verboseLogging.helpShort = "Enable verbose logging output"
+        argument.verboseLogging.helpUsage = ""
+        argument.verboseLogging.helpLong = """
+        Enables verbose logging. Debug and error messages will be printed to stderr.
+"""
+
+        argument.constructionKit.helpShort = "Launch the swiftDialog builder UI"
+        argument.constructionKit.helpUsage = ""
+        argument.constructionKit.helpLong = """
+        Activates the swiftDialog construction kit / builder interface for
+        real-time configuration and preview of dialog settings.
+"""
+
+        argument.ignoreDND.helpShort = "Ignore Do Not Disturb settings"
+        argument.ignoreDND.helpUsage = ""
+        argument.ignoreDND.helpLong = """
+        When set, swiftDialog will ignore the system Do Not Disturb setting
+        and display notifications and play sounds regardless.
+"""
+
+        argument.eulaMode.helpShort = "Enable EULA display mode"
+        argument.eulaMode.helpUsage = ""
+        argument.eulaMode.helpLong = """
+        Displays the message content in a monospaced font within a scrollable list area,
+        suited for presenting license agreements or legal text.
+"""
+
+        argument.notificationGoPing.helpShort = "Enable notification sounds"
+        argument.notificationGoPing.helpUsage = ""
+        argument.notificationGoPing.helpLong = """
+        When sending a system notification via --\(argument.notification.long),
+        enables the notification sound.
+"""
+
+        argument.alwaysReturnUserInput.helpShort = "Always return user input regardless of exit code"
+        argument.alwaysReturnUserInput.helpUsage = ""
+        argument.alwaysReturnUserInput.helpLong = """
+        By default, user input (textfields, checkboxes, dropdowns) is only returned
+        when swiftDialog exits with code 0 (button 1 / success).
+        When this flag is set, user input is returned for all exit codes.
+"""
+
+        argument.hideTimer.helpShort = "Hide the autoplay timer on image carousels"
+        argument.hideTimer.helpUsage = ""
+        argument.hideTimer.helpLong = """
+        When images are displayed as a carousel with --\(argument.autoPlay.long),
+        this option hides the countdown timer indicator between image transitions.
+"""
+
+        argument.demoOption.helpShort = "Enable demo mode"
+        argument.demoOption.helpUsage = ""
+        argument.demoOption.helpLong = """
+        Launches swiftDialog in demonstration mode with sample content
+        for testing and preview purposes.
+"""
+
+        argument.listFonts.helpShort = "List all available fonts"
+        argument.listFonts.helpUsage = ""
+        argument.listFonts.helpLong = """
+        Prints all available font families and font names on the system to stdout,
+        then exits. Useful for determining valid values for --\(argument.titleFont.long)
+        and other font-related options.
 """
     }
 

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -65,6 +65,19 @@ func getJSON() -> JSON {
         // read json in from text string
         json = processJSONString(jsonString: CLOptionText(optionName: appArguments.jsonString))
     }
+    
+    // Check for cards mode and load cards if present
+    if json["cards"].exists() && json["cards"].type == .array && !json["cards"].arrayValue.isEmpty {
+        writeLog("Cards array detected in JSON configuration")
+        if cardState.loadCards(from: json) {
+            writeLog("Cards mode activated with \(cardState.totalCards) cards")
+            // Return the first card's configuration for initial setup
+            if let firstCard = cardState.currentCard {
+                return firstCard.configuration
+            }
+        }
+    }
+    
     return json
 }
 

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -71,9 +71,10 @@ func getJSON() -> JSON {
         writeLog("Cards array detected in JSON configuration")
         if cardState.loadCards(from: json) {
             writeLog("Cards mode activated with \(cardState.totalCards) cards")
-            // Return the first card's configuration for initial setup
+            // Return the merged configuration (global defaults + first card) for initial setup
+            // This ensures window properties like height, width, ontop, moveable are applied
             if let firstCard = cardState.currentCard {
-                return firstCard.configuration
+                return cardState.getMergedConfiguration(for: firstCard)
             }
         }
     }

--- a/dialog/Command Line/ProcessCLOptions.swift
+++ b/dialog/Command Line/ProcessCLOptions.swift
@@ -945,6 +945,9 @@ func processCLOptions(json: JSON = getJSON()) {
             if json[appArguments.titleFont.long]["alignment"].exists() {
                 appvars.titleFontAlignment = json[appArguments.titleFont.long]["alignment"].stringValue
             }
+            if json[appArguments.titleFont.long]["offset"].exists() {
+                appvars.titleFontOffset = json[appArguments.titleFont.long]["offset"].number as! CGFloat
+            }
         } else {
             writeLog("titleFont.value : \(appArguments.titleFont.value)")
             let fontCLValues = appArguments.titleFont.value
@@ -974,6 +977,9 @@ func processCLOptions(json: JSON = getJSON()) {
                     case  "alignment":
                         appvars.titleFontAlignment = item[1]
                         writeLog("titleFontAlignment : \(appvars.titleFontAlignment)")
+                    case "offset":
+                        appvars.titleFontOffset = item[1].floatValue()
+                        writeLog("titleFontOffset : \(appvars.titleFontOffset)")
                     default:
                         writeLog("Unknown paramater \(item[0])")
                 }

--- a/dialog/Functions/Images.swift
+++ b/dialog/Functions/Images.swift
@@ -151,4 +151,13 @@ func generateQRCode(from string: String, withSize: CGFloat? = 300) -> NSImage {
 func setAppIcon(named name: String) {
     let iconImage = getImageFromPath(fileImagePath: name)
     NSWorkspace.shared.setIcon(iconImage, forFile: Bundle.main.bundlePath)
+
+    // Also update the icons of the embedded notifier helper apps
+    let helpersURL = URL(fileURLWithPath: Bundle.main.bundlePath)
+        .appending(path: "Contents/Helpers", directoryHint: .isDirectory)
+    let notifierApps = (try? FileManager.default.contentsOfDirectory(atPath: helpersURL.path)) ?? []
+    for appName in notifierApps where appName.hasSuffix(".app") {
+        let appPath = helpersURL.appending(path: appName).path
+        NSWorkspace.shared.setIcon(iconImage, forFile: appPath)
+    }
 }

--- a/dialog/Functions/Notifications.swift
+++ b/dialog/Functions/Notifications.swift
@@ -31,6 +31,11 @@ func checkNotificationAuthorisation(notificationPresent: Bool) {
 func checkForDialogNotificationMode(_ arguments: CommandLineArguments) -> Bool {
     // check if we are sending a notification
     if arguments.notification.present && dialogIsAuthorised {
+        // Deprecation notice: sending notifications via the main Dialog app bundle is deprecated.
+        // Admins should migrate to using `--style banner` or `--style alert` via dialogcli,
+        // which routes to dedicated helper apps with separate bundle IDs.
+        // This legacy path will be removed in a future major version.
+        fputs("WARNING: Sending notifications via Dialog.app is deprecated. Use --style banner or --style alert for new deployments.\n", stderr)
         if arguments.removeNotification.present {
             writeLog("Removing notifications")
             removeNotification(identifier: arguments.notificationIdentifier.value)

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -57,6 +57,73 @@ func checkRegexPattern(regexPattern: String, textToValidate: String) -> Bool {
     return  returnValue
 }
 
+/// Validates required fields and regex patterns for the current card/dialog
+/// - Parameter observedObject: The dialog content to validate
+/// - Returns: A tuple of (isValid, errorMessage) where isValid is true if validation passed
+func validateRequiredFields(observedObject: DialogUpdatableContent) -> (isValid: Bool, errorMessage: String) {
+    var requiredString = ""
+    var isValid = true
+    
+    // Validate text fields
+    if appArguments.textField.present {
+        writeLog("Validating text fields for required and regex")
+        
+        for index in 0..<(userInputState.textFields.count) {
+            let textField = userInputState.textFields[index]
+            let textfieldValue = textField.value
+            let textfieldTitle = textField.title
+            let textfieldRequired = textField.required
+            let textfieldValidation = textField.confirm
+            let textFieldValidationValue = textField.validationValue
+            userInputState.textFields[index].requiredTextfieldHighlight = Color.clear
+            
+            if textfieldRequired && textfieldValue == "" {
+                NSSound.beep()
+                requiredString += "  - \"\(textfieldTitle)\" \("is required".localized)<br>"
+                userInputState.textFields[index].requiredTextfieldHighlight = Color.red
+                isValid = false
+                writeLog("Required text field \(textfieldTitle) has no value")
+            } else if !(textfieldValue.isEmpty)
+                        && !(textField.regex.isEmpty)
+                        && !checkRegexPattern(regexPattern: textField.regex, textToValidate: textfieldValue) {
+                NSSound.beep()
+                userInputState.textFields[index].requiredTextfieldHighlight = Color.green
+                requiredString += "  - "+(textField.regexError)+"<br>"
+                isValid = false
+                writeLog("Textfield \(textfieldTitle) value \(textfieldValue) does not meet regex requirements \(String(describing: textField.regex))")
+            } else if textfieldValidation && textFieldValidationValue != textfieldValue {
+                NSSound.beep()
+                requiredString += "  - \"\(textfieldTitle)\" \("confirmation failed  <br>values do not match".localized)<br>"
+                userInputState.textFields[index].requiredTextfieldHighlight = Color.red
+                isValid = false
+                writeLog("Text field \(textfieldTitle) confirmation failed")
+            }
+        }
+    }
+    
+    // Validate dropdown/select items
+    if observedObject.args.dropdownValues.present {
+        writeLog("Validating select items for required")
+        
+        for index in 0..<(userInputState.dropdownItems.count) {
+            let dropdownItem = userInputState.dropdownItems[index]
+            let dropdownItemSelectedValue = dropdownItem.selectedValue
+            let dropdownItemRequired = dropdownItem.required
+            userInputState.dropdownItems[index].requiredfieldHighlight = Color.clear
+            
+            if dropdownItemRequired && dropdownItemSelectedValue == "" {
+                NSSound.beep()
+                requiredString += "  - \"\(dropdownItem.title)\" \("is required".localized)<br>"
+                userInputState.dropdownItems[index].requiredfieldHighlight = Color.red
+                isValid = false
+                writeLog("Required select item \(dropdownItem.title) has no value")
+            }
+        }
+    }
+    
+    return (isValid, requiredString.replacingOccurrences(of: "<br>", with: "\n"))
+}
+
 func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true, observedObject: DialogUpdatableContent, isCardsMode: Bool = false) {
     writeLog("processing button action \(action)")
     if action != "" {

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -57,7 +57,7 @@ func checkRegexPattern(regexPattern: String, textToValidate: String) -> Bool {
     return  returnValue
 }
 
-func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true, observedObject: DialogUpdatableContent) {
+func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true, observedObject: DialogUpdatableContent, isCardsMode: Bool = false) {
     writeLog("processing button action \(action)")
     if action != "" {
         if executeShell {
@@ -67,6 +67,10 @@ func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQui
         }
     }
     if shouldQuit {
+        // In cards mode, store final card input before quitting
+        if isCardsMode && cardState.isCardsMode {
+            cardState.storeCurrentCardInput(observedObject.collectCurrentUserInput())
+        }
         quitDialog(exitCode: exitCode, observedObject: observedObject)
     }
 }
@@ -216,17 +220,71 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "", observedObject: Dial
         }
 
         // print the output
-        if observedObject?.args.jsonOutPut.present ?? false {
-            print(json)
+        if cardState.isCardsMode {
+            // Cards mode: output all accumulated input from all cards
+            writeLog("Cards mode: outputting accumulated input from \(cardState.totalCards) cards")
+            
+            if observedObject?.args.jsonOutPut.present ?? false {
+                // JSON output for cards mode - include current card's input plus accumulated
+                var cardsJson = JSON()
+                let allInput = cardState.getAllAccumulatedInput()
+                
+                // Add all accumulated input to the JSON
+                for (key, value) in allInput {
+                    if let dictValue = value as? [String: Any] {
+                        cardsJson[key] = JSON(dictValue)
+                    } else if let boolValue = value as? Bool {
+                        cardsJson[key].bool = boolValue
+                    } else if let stringValue = value as? String {
+                        cardsJson[key].string = stringValue
+                    } else {
+                        cardsJson[key] = JSON(value)
+                    }
+                }
+                
+                // Merge current card's json output
+                for (key, value) in json {
+                    cardsJson[key] = value
+                }
+                
+                print(cardsJson)
+            } else {
+                // Plain text output for cards mode
+                let allInput = cardState.getAllAccumulatedInput()
+                for (key, value) in allInput {
+                    if let dictValue = value as? [String: Any] {
+                        if let selectedValue = dictValue["selectedValue"] {
+                            print("\"\(key)\" : \"\(selectedValue)\"")
+                        }
+                        if let selectedIndex = dictValue["selectedIndex"] {
+                            print("\"\(key)\" index : \"\(selectedIndex)\"")
+                        }
+                    } else {
+                        print("\"\(key)\" : \"\(value)\"")
+                    }
+                }
+                // Also print current card's output
+                for index in 0..<outputArray.count {
+                    print(outputArray[index])
+                }
+            }
         } else {
-            for index in 0..<outputArray.count {
-                print(outputArray[index])
+            // Normal mode: original output behavior
+            if observedObject?.args.jsonOutPut.present ?? false {
+                print(json)
+            } else {
+                for index in 0..<outputArray.count {
+                    print(outputArray[index])
+                }
             }
         }
     }
     if appArguments.hideOtherApps.present {
         NSApp.unhideAllApplications(nil)
     }
+    
+    // Reset card state on exit
+    cardState.reset()
     
     exit(exitCode)
 }

--- a/dialog/Functions/System.swift
+++ b/dialog/Functions/System.swift
@@ -124,6 +124,84 @@ func validateRequiredFields(observedObject: DialogUpdatableContent) -> (isValid:
     return (isValid, requiredString.replacingOccurrences(of: "<br>", with: "\n"))
 }
 
+/// Executes the onAdvance callback command with card input as JSON on stdin
+/// - Parameters:
+///   - command: The shell command to execute
+///   - cardIndex: The current card index
+///   - cardId: The current card ID (from JSON config, if specified)
+///   - input: The user input from the current card
+/// - Returns: A tuple of (success, errorMessage) where success is true if callback returned 0
+func executeOnAdvanceCallback(command: String, cardIndex: Int, cardId: String?, input: [String: Any]) -> (success: Bool, errorMessage: String) {
+    writeLog("Executing onAdvance callback: \(command)")
+    
+    // Build JSON payload
+    var payload: [String: Any] = [
+        "cardIndex": cardIndex,
+        "input": input
+    ]
+    if let cardId = cardId {
+        payload["cardId"] = cardId
+    }
+    
+    // Convert to JSON string
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload, options: []),
+          let jsonString = String(data: jsonData, encoding: .utf8) else {
+        writeLog("Failed to serialize callback payload to JSON", logLevel: .error)
+        return (false, "Internal error: failed to serialize callback data")
+    }
+    
+    writeLog("Callback JSON payload: \(jsonString)", logLevel: .debug)
+    
+    let task = Process()
+    let inputPipe = Pipe()
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    
+    task.standardInput = inputPipe
+    task.standardOutput = outputPipe
+    task.standardError = errorPipe
+    task.arguments = ["-c", command]
+    task.launchPath = "/bin/zsh"
+    
+    do {
+        try task.run()
+        
+        // Write JSON to stdin
+        inputPipe.fileHandleForWriting.write(jsonString.data(using: .utf8)!)
+        inputPipe.fileHandleForWriting.closeFile()
+        
+        task.waitUntilExit()
+        
+        let exitCode = task.terminationStatus
+        writeLog("onAdvance callback exited with code: \(exitCode)")
+        
+        if exitCode == 0 {
+            return (true, "")
+        } else {
+            // Read stderr for error message
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            var errorMessage = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            
+            // If no error message, read stdout
+            if errorMessage.isEmpty {
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                errorMessage = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            }
+            
+            // Default error message if none provided
+            if errorMessage.isEmpty {
+                errorMessage = "Callback command returned non-zero exit code (\(exitCode))"
+            }
+            
+            writeLog("onAdvance callback failed: \(errorMessage)", logLevel: .error)
+            return (false, errorMessage)
+        }
+    } catch {
+        writeLog("Failed to execute onAdvance callback: \(error.localizedDescription)", logLevel: .error)
+        return (false, "Failed to execute callback: \(error.localizedDescription)")
+    }
+}
+
 func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true, observedObject: DialogUpdatableContent, isCardsMode: Bool = false) {
     writeLog("processing button action \(action)")
     if action != "" {

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4952</string>
+	<string>4954</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -8,6 +8,8 @@
 	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -19,16 +21,14 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4966</string>
+	<string>4967</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>CFBundleIconFile</key>
-	<string>AppIcon</string>
-	<key>NSUserNotificationAlertStyle</key>
-	<string>banner</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>banner</string>
 </dict>
 </plist>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -24,6 +24,10 @@
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>banner</string>
 	<key>LSUIElement</key>
 	<true/>
 </dict>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4954</string>
+	<string>4960</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>4960</string>
+	<string>4966</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -682,6 +682,9 @@ final class DialogUpdatableContent: ObservableObject {
 
     @Published var updateView: Bool = true
     @Published var constructionKitShown: Bool = false
+    
+    /// Current card index for cards mode - used to force view recreation
+    @Published var currentCardIndex: Int = 0
 
     var status: StatusState
 
@@ -830,10 +833,11 @@ final class DialogUpdatableContent: ObservableObject {
         userInputState.checkBoxes.removeAll()
         userInputState.listItems.removeAll()
         
-        // Update observed arrays
+        // Update observed arrays and state
         textFieldArray = []
         dropdownArray = []
         listItemsArray = []
+        observedUserInputState = userInputState
     }
     
     /// Apply a card's configuration to the current dialog state
@@ -844,22 +848,107 @@ final class DialogUpdatableContent: ObservableObject {
         // Clear previous user input state
         clearUserInputState()
         
-        // Update appArguments with the card's configuration
-        appArguments.updateAllItems(with: card.configuration)
+        // Reset appArguments to defaults first
+        // This ensures properties not specified in the card revert to defaults
+        appArguments.resetToDefaults()
         
-        // Refresh our local args reference
+        // Get the merged configuration (global defaults + card overrides)
+        let mergedConfig = cardState.getMergedConfiguration(for: card)
+        
+        // Get card input variables for substitution in text fields
+        // This allows using {fieldname} syntax to reference values from previous cards
+        let cardInputVariables = cardState.getInputAsVariables()
+        
+        // Merge card input variables with system info for text processing
+        var combinedTags = appvars.systemInfo
+        for (key, value) in cardInputVariables {
+            combinedTags[key] = value
+        }
+        
+        // Update appArguments with the merged configuration (global + card)
+        appArguments.updateAllItems(with: mergedConfig)
+        
+        // Re-process options that need special handling (uses merged config)
+        // This must happen BEFORE variable substitution as it sets up dropdowns, checkboxes, etc.
+        processCLOptions(json: mergedConfig)
+        
+        // Apply variable substitution to text fields that support it
+        // Title, subtitle, message, etc. can use {fieldname} from previous cards
+        if !cardInputVariables.isEmpty {
+            appArguments.titleOption.value = processTextString(appArguments.titleOption.value, tags: combinedTags)
+            appArguments.subTitleOption.value = processTextString(appArguments.subTitleOption.value, tags: combinedTags)
+            appArguments.messageOption.value = processTextString(appArguments.messageOption.value, tags: combinedTags)
+            appArguments.button1TextOption.value = processTextString(appArguments.button1TextOption.value, tags: combinedTags)
+            appArguments.button2TextOption.value = processTextString(appArguments.button2TextOption.value, tags: combinedTags)
+            appArguments.infoBox.value = processTextString(appArguments.infoBox.value, tags: combinedTags)
+            appArguments.helpMessage.value = processTextString(appArguments.helpMessage.value, tags: combinedTags)
+        }
+        
+        // Refresh our local args reference AFTER processCLOptions
+        // This ensures dropdownValues.present, checkbox.present etc. are correctly set
         args = appArguments
         
-        // Re-process options that need special handling
-        processCLOptions(json: card.configuration)
+        // Check if we have stored input for this card (user navigated back)
+        // and restore the values
+        if let storedInput = cardState.getStoredInput(for: cardState.currentCardIndex) {
+            restoreUserInput(from: storedInput)
+        }
         
-        // Update the observed arrays from the global state
+        // Update the observed arrays and state from the global state
         textFieldArray = userInputState.textFields
         dropdownArray = userInputState.dropdownItems
         listItemsArray = userInputState.listItems
+        observedUserInputState = userInputState
+        
+        // Update current card index - this triggers view recreation via .id() modifier
+        currentCardIndex = cardState.currentCardIndex
         
         // Force UI update
         objectWillChange.send()
+    }
+    
+    /// Restore user input values from stored data (when navigating back)
+    /// - Parameter storedInput: Dictionary of field names to their stored values
+    private func restoreUserInput(from storedInput: [String: Any]) {
+        writeLog("Restoring user input for card \(cardState.currentCardIndex + 1)")
+        
+        // Restore text field values
+        for index in 0..<userInputState.textFields.count {
+            let key = userInputState.textFields[index].name.isEmpty 
+                ? userInputState.textFields[index].title 
+                : userInputState.textFields[index].name
+            if let value = storedInput[key] as? String {
+                userInputState.textFields[index].value = value
+            }
+        }
+        
+        // Restore dropdown selections
+        for index in 0..<userInputState.dropdownItems.count {
+            let key = userInputState.dropdownItems[index].name.isEmpty 
+                ? userInputState.dropdownItems[index].title 
+                : userInputState.dropdownItems[index].name
+            if let dictValue = storedInput[key] as? [String: Any],
+               let selectedValue = dictValue["selectedValue"] as? String {
+                userInputState.dropdownItems[index].selectedValue = selectedValue
+            }
+        }
+        
+        // Restore checkbox values
+        for index in 0..<userInputState.checkBoxes.count {
+            let key = userInputState.checkBoxes[index].name.isEmpty 
+                ? userInputState.checkBoxes[index].label 
+                : userInputState.checkBoxes[index].name
+            if let checked = storedInput[key] as? Bool {
+                userInputState.checkBoxes[index].checked = checked
+            }
+        }
+        
+        // Restore list selections
+        for index in 0..<userInputState.listItems.count {
+            if let selected = storedInput[userInputState.listItems[index].title] as? Bool {
+                userInputState.listItems[index].selected = selected
+            }
+        }
     }
     
     /// Advance to the next card

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -58,7 +58,7 @@ class FileReader {
         }
         fileHandle?.waitForDataInBackgroundAndNotify()
 
-        dataAvailable = NotificationCenter.default.addObserver(forName: NSNotification.Name.NSFileHandleDataAvailable, object: self.fileHandle, queue: nil) { _ in
+        dataAvailable = NotificationCenter.default.addObserver(forName: NSNotification.Name.NSFileHandleDataAvailable, object: self.fileHandle, queue: .main) { _ in
             if let data = self.fileHandle?.availableData,
                data.count > 0 {
                 self.parseAndPrint(data: data)
@@ -899,6 +899,15 @@ final class DialogUpdatableContent: ObservableObject {
         // Refresh our local args reference AFTER processCLOptions
         // This ensures dropdownValues.present, checkbox.present etc. are correctly set
         args = appArguments
+        
+        // Update progress bar settings if present in card config
+        if args.progressBar.present {
+            progressTotal = Double(args.progressBar.value) ?? 100
+            // Start with indeterminate progress (nil) - value is set via command file
+            // The "progress" JSON key sets the total, not the current value
+            progressValue = nil
+            writeLog("Card progress bar: total=\(progressTotal), starting indeterminate")
+        }
         
         // Sync window properties from appvars (updated by processCLOptions)
         // This allows cards to specify different window sizes

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -784,4 +784,115 @@ final class DialogUpdatableContent: ObservableObject {
             }
         }
     }
+    
+    // MARK: - Cards Mode Support
+    
+    /// Collect current user input from all input fields
+    /// Returns a dictionary of field names to their values
+    func collectCurrentUserInput() -> [String: Any] {
+        var input: [String: Any] = [:]
+        
+        // Collect text field values
+        for textField in userInputState.textFields {
+            let key = textField.name.isEmpty ? textField.title : textField.name
+            input[key] = textField.value
+        }
+        
+        // Collect dropdown selections
+        for dropdown in userInputState.dropdownItems {
+            let key = dropdown.name.isEmpty ? dropdown.title : dropdown.name
+            input[key] = [
+                "selectedValue": dropdown.selectedValue,
+                "selectedIndex": dropdown.values.firstIndex(of: dropdown.selectedValue) ?? -1
+            ]
+        }
+        
+        // Collect checkbox values
+        for checkbox in userInputState.checkBoxes {
+            let key = checkbox.name.isEmpty ? checkbox.label : checkbox.name
+            input[key] = checkbox.checked
+        }
+        
+        // Collect list selections if enabled
+        if args.listSelectionEnabled.present {
+            for item in userInputState.listItems {
+                input[item.title] = item.selected
+            }
+        }
+        
+        return input
+    }
+    
+    /// Clear user input state for a fresh card
+    func clearUserInputState() {
+        userInputState.textFields.removeAll()
+        userInputState.dropdownItems.removeAll()
+        userInputState.checkBoxes.removeAll()
+        userInputState.listItems.removeAll()
+        
+        // Update observed arrays
+        textFieldArray = []
+        dropdownArray = []
+        listItemsArray = []
+    }
+    
+    /// Apply a card's configuration to the current dialog state
+    /// - Parameter card: The card configuration to apply
+    func applyCardConfiguration(_ card: DialogCard) {
+        writeLog("Applying card \(card.id) configuration")
+        
+        // Clear previous user input state
+        clearUserInputState()
+        
+        // Update appArguments with the card's configuration
+        appArguments.updateAllItems(with: card.configuration)
+        
+        // Refresh our local args reference
+        args = appArguments
+        
+        // Re-process options that need special handling
+        processCLOptions(json: card.configuration)
+        
+        // Update the observed arrays from the global state
+        textFieldArray = userInputState.textFields
+        dropdownArray = userInputState.dropdownItems
+        listItemsArray = userInputState.listItems
+        
+        // Force UI update
+        objectWillChange.send()
+    }
+    
+    /// Advance to the next card
+    /// - Returns: True if advanced, false if on last card (should exit)
+    func advanceToNextCard() -> Bool {
+        // Store current input before advancing
+        cardState.storeCurrentCardInput(collectCurrentUserInput())
+        
+        // Try to advance
+        if cardState.nextCard() {
+            if let nextCard = cardState.currentCard {
+                applyCardConfiguration(nextCard)
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Go back to the previous card
+    /// - Returns: True if moved back, false if on first card
+    func goToPreviousCard() -> Bool {
+        // Store current input before going back
+        cardState.storeCurrentCardInput(collectCurrentUserInput())
+        
+        // Try to go back
+        if cardState.previousCard() {
+            if let prevCard = cardState.currentCard {
+                applyCardConfiguration(prevCard)
+                return true
+            }
+        }
+        
+        return false
+    }
 }

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -845,12 +845,24 @@ final class DialogUpdatableContent: ObservableObject {
     func applyCardConfiguration(_ card: DialogCard) {
         writeLog("Applying card \(card.id) configuration")
         
+        // Update current card index FIRST and force UI update
+        // This triggers view recreation via .id() modifier BEFORE data changes
+        // Critical: this must happen before clearing/updating userInputState to avoid index out of range
+        currentCardIndex = cardState.currentCardIndex
+        objectWillChange.send()
+        
         // Clear previous user input state
         clearUserInputState()
         
         // Reset appArguments to defaults first
         // This ensures properties not specified in the card revert to defaults
         appArguments.resetToDefaults()
+        
+        // Reset appvars window dimensions to defaults
+        // processCLOptions only updates these if the arguments are present,
+        // so we need to reset them before processing the new card config
+        appvars.windowWidth = 820  // Default from AppVariables
+        appvars.windowHeight = 380 // Default from AppVariables
         
         // Get the merged configuration (global defaults + card overrides)
         let mergedConfig = cardState.getMergedConfiguration(for: card)
@@ -888,6 +900,24 @@ final class DialogUpdatableContent: ObservableObject {
         // This ensures dropdownValues.present, checkbox.present etc. are correctly set
         args = appArguments
         
+        // Sync window properties from appvars (updated by processCLOptions)
+        // This allows cards to specify different window sizes
+        let windowSizeChanged = appProperties.windowWidth != appvars.windowWidth || 
+                                appProperties.windowHeight != appvars.windowHeight
+        appProperties.windowWidth = appvars.windowWidth
+        appProperties.windowHeight = appvars.windowHeight
+        
+        // Resize window if dimensions changed
+        if windowSizeChanged, let window = mainWindow ?? NSApp.windows.first {
+            writeLog("Card resizing window to \(appvars.windowWidth) x \(appvars.windowHeight)")
+            placeWindow(window, 
+                       size: CGSize(width: appProperties.windowWidth, height: appProperties.windowHeight + 28),
+                       vertical: appProperties.windowPositionVertical,
+                       horozontal: appProperties.windowPositionHorozontal,
+                       offset: args.positionOffset.value.floatValue(),
+                       useFullScreen: args.blurScreen.present || args.forceOnTop.present)
+        }
+        
         // Check if we have stored input for this card (user navigated back)
         // and restore the values
         if let storedInput = cardState.getStoredInput(for: cardState.currentCardIndex) {
@@ -900,10 +930,7 @@ final class DialogUpdatableContent: ObservableObject {
         listItemsArray = userInputState.listItems
         observedUserInputState = userInputState
         
-        // Update current card index - this triggers view recreation via .id() modifier
-        currentCardIndex = cardState.currentCardIndex
-        
-        // Force UI update
+        // Force final UI update
         objectWillChange.send()
     }
     

--- a/dialog/Updatable Content/DialogUpdatableContent.swift
+++ b/dialog/Updatable Content/DialogUpdatableContent.swift
@@ -548,16 +548,19 @@ class FileReader {
                 activateDialog()
 
             // minimize
-            case "miniaturize:":
+            case "minimize:", "minimise:":
                 writeToLog("minimizing windows")
                 if observedData.args.blurScreen.present {
                     blurredScreen.hide()
                 }
-                NSApp.keyWindow?.setIsMiniaturized(true)
+                activateDialog()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    NSApp.keyWindow?.setIsMiniaturized(true)
+                }
 
-            // deminimize
-            case "deminiaturize:":
-                writeToLog("deminimizing windows")
+            // maximize
+            case "maximize:", "maximise:":
+                writeToLog("maximizing windows")
                 if observedData.args.blurScreen.present {
                     blurredScreen.show()
                 }

--- a/dialog/Views/BannerImageView.swift
+++ b/dialog/Views/BannerImageView.swift
@@ -18,11 +18,9 @@ struct BannerImageView: View {
     var maxBannerHeight: CGFloat = 130
     var minBannerHeight: CGFloat = 100
 
-    let blurRadius: CGFloat = 3
-    let opacity: CGFloat = 0.5
-    let blurOffset: CGFloat = 2
-
-    //let size: CGFloat
+    let blurRadius: CGFloat = 5
+    let opacity: CGFloat = 1 //0.8
+    let blurOffset: CGFloat = 3
 
     init(observedDialogContent: DialogUpdatableContent) {
         self.observedData = observedDialogContent
@@ -37,9 +35,19 @@ struct BannerImageView: View {
     var body: some View {
         ZStack {
             if observedData.args.bannerImage.value.range(of: "colo[u]?r=", options: .regularExpression) != nil {
-                SolidColourView(colourValue: observedData.args.bannerImage.value)
+                if let colourValue = observedData.args.bannerImage.value.split(usingRegex: "colo[u]?r=").last {
+                    SolidColourView(colourValue: colourValue.split(usingRegex: ",").first ?? "accent",
+                                    withGradient: colourValue.split(usingRegex: ",").last != "nogradient"
+                    )
                     .frame(maxHeight: maxBannerHeight)
-                    //.frame(minHeight: 100)
+                }
+            } else if observedData.args.bannerImage.value.range(of: "gradient=", options: .regularExpression) != nil {
+                if let colourValues = observedData.args.bannerImage.value.split(usingRegex: "gradient=").last {
+                    // angle degrees is the last element if it contains the text angle=, otherwise it's 90
+                    GradientColourView(colourValues: colourValues.split(usingRegex: ":").first ?? "accent",
+                                       angleDegrees: Double(colourValues.split(usingRegex: ":").last?.split(usingRegex: "angle=").last ?? "90") ?? 90 )
+                    .frame(maxHeight: maxBannerHeight)
+                }
             } else {
                 DisplayImage(observedData.args.bannerImage.value, corners: false, showBackgroundOnError: true)
                     .aspectRatio(contentMode: .fill)
@@ -51,26 +59,8 @@ struct BannerImageView: View {
                     .clipped()
             }
             if observedData.args.bannerTitle.present {
-                HStack {
-                    if observedData.appProperties.titleFontAlignment.lowercased() == "right" {
-                        Spacer()
-                    }
-                    InlineText(observedData.args.titleOption.value, parser: ColoredMarkdownParser())
-                        .font(
-                            observedData.appProperties.titleFontName.isEmpty ?
-                                .system(size: observedData.appProperties.titleFontSize, weight: observedData.appProperties.titleFontWeight) :
-                                    .custom(observedData.appProperties.titleFontName, size: observedData.appProperties.titleFontSize)
-                        )
-                        .fontWeight(observedData.appProperties.titleFontWeight)
-                        .foregroundColor(observedData.appProperties.titleFontColour)
-                        .accessibilityHint(observedData.args.titleOption.value)
-                        .shadow(radius: observedData.appProperties.titleFontShadow ? blurRadius : 0)
-                        .padding(appDefaults.topPadding)
-                        .frame(alignment: .center)
-                    if observedData.appProperties.titleFontAlignment.lowercased() == "left" {
-                        Spacer()
-                    }
-                }
+                TitleView(observedData: observedData)
+                    .shadow(radius: observedData.appProperties.titleFontShadow ? blurRadius : 0)
             }
         }
     }

--- a/dialog/Views/ButtonBarView.swift
+++ b/dialog/Views/ButtonBarView.swift
@@ -77,24 +77,34 @@ struct ButtonBarView: View {
             // Additional Buttons can go here if we implement it
            
             // Define an array of buttons for display
+            // In cards mode: button1 = Next (or Finish on last card), button2 = Previous
             let buttonArray: [AnyView]   = [
-                // Default Cancel button
-                AnyView(NewButton(label: observedData.args.button2TextOption.value == "nil" ? "" : observedData.args.button2TextOption.value,
-                          isVisible: (observedData.args.button2Option.present || observedData.args.button2TextOption.present),
-                          isDisabled: observedData.args.button2Disabled.present,
+                // Button 2: Cancel in normal mode, Previous in cards mode
+                AnyView(NewButton(label: cardState.isCardsMode
+                          ? (cardState.isFirstCard ? "" : "Previous".localized)
+                          : (observedData.args.button2TextOption.value == "nil" ? "" : observedData.args.button2TextOption.value),
+                          isVisible: cardState.isCardsMode
+                          ? !cardState.isFirstCard
+                          : (observedData.args.button2Option.present || observedData.args.button2TextOption.present),
+                          isDisabled: cardState.isCardsMode
+                          ? false
+                          : observedData.args.button2Disabled.present,
                           enableOnChangeOf: $observedData.args.button2Disabled.present,
                           isStacked: buttonStackStyle,
-                          symbolName: observedData.args.button2Symbol.value,
-                          symbolIsVisible: observedData.args.button2Symbol.present,
+                          symbolName: cardState.isCardsMode ? "" : observedData.args.button2Symbol.value,
+                          symbolIsVisible: cardState.isCardsMode ? false : observedData.args.button2Symbol.present,
                           keyboardShortcut: .cancelAction,
                           buttonFontSize: observedData.appProperties.buttonTextSize,
                           buttonStyle: observedData.appProperties.buttonSize,
-                          shouldQuit: true,
+                          isCardsPreviousButton: cardState.isCardsMode && !cardState.isFirstCard,
+                          shouldQuit: cardState.isCardsMode ? false : true,
                           exitCode: 2,
                           observedData: observedData
                 )),
-                // Default Primary button
-                AnyView(NewButton(label: observedData.args.button1TextOption.value == "nil" ? "" : observedData.args.button1TextOption.value,
+                // Button 1: OK in normal mode, Next/Finish in cards mode
+                AnyView(NewButton(label: cardState.isCardsMode
+                          ? (cardState.isLastCard ? (observedData.args.button1TextOption.value == appDefaults.button1Default ? "Finish".localized : observedData.args.button1TextOption.value) : "Next".localized)
+                          : (observedData.args.button1TextOption.value == "nil" ? "" : observedData.args.button1TextOption.value),
                           isVisible: (observedData.args.button1TextOption.value != "none"),
                           isDisabled: observedData.args.button1Disabled.present,
                           enableOnTimer: (observedData.args.timerBar.present && !observedData.args.hideTimerBar.present),
@@ -105,7 +115,8 @@ struct ButtonBarView: View {
                           keyboardShortcut: .defaultAction,
                           buttonFontSize: observedData.appProperties.buttonTextSize,
                           buttonStyle: observedData.appProperties.buttonSize,
-                          shouldQuit: true,
+                          isCardsNextButton: cardState.isCardsMode,
+                          shouldQuit: cardState.isCardsMode ? cardState.isLastCard : true,
                           exitCode: 0,
                           observedData: observedData
                 ))
@@ -214,6 +225,8 @@ struct NewButton: View {
     var buttonStyle: ControlSize = .regular
     var action: String = ""
     var isShellCommand: Bool = false
+    var isCardsNextButton: Bool = false      // Cards mode: this is the Next/Finish button
+    var isCardsPreviousButton: Bool = false  // Cards mode: this is the Previous button
     var shouldQuit: Bool = false
     var exitCode: Int32 = 0
     @ObservedObject var observedData: DialogUpdatableContent
@@ -266,7 +279,23 @@ struct NewButton: View {
             let symbolLayout = (symbolPosition == .top || symbolPosition == .bottom) ? AnyLayout(VStackLayout()) : AnyLayout(HStackLayout())
             
             Button(action: {
-                buttonAction(action: action, exitCode: exitCode, executeShell: isShellCommand, shouldQuit: shouldQuit, observedObject: observedData)
+                // Handle cards mode navigation
+                if isCardsNextButton && cardState.isCardsMode {
+                    // Next button in cards mode
+                    if cardState.isLastCard {
+                        // On last card, collect input and quit
+                        buttonAction(action: action, exitCode: exitCode, executeShell: isShellCommand, shouldQuit: true, observedObject: observedData, isCardsMode: true)
+                    } else {
+                        // Advance to next card
+                        _ = observedData.advanceToNextCard()
+                    }
+                } else if isCardsPreviousButton && cardState.isCardsMode {
+                    // Previous button in cards mode - go back
+                    _ = observedData.goToPreviousCard()
+                } else {
+                    // Normal mode - original behavior
+                    buttonAction(action: action, exitCode: exitCode, executeShell: isShellCommand, shouldQuit: shouldQuit, observedObject: observedData)
+                }
             }, label: {
                 symbolLayout {
                     if !label.isEmpty && (symbolPosition == .bottom) {

--- a/dialog/Views/ButtonBarView.swift
+++ b/dialog/Views/ButtonBarView.swift
@@ -281,6 +281,15 @@ struct NewButton: View {
             Button(action: {
                 // Handle cards mode navigation
                 if isCardsNextButton && cardState.isCardsMode {
+                    // Validate required fields before advancing or finishing
+                    let validation = validateRequiredFields(observedObject: observedData)
+                    if !validation.isValid {
+                        // Show validation error sheet
+                        observedData.sheetErrorMessage = validation.errorMessage
+                        observedData.showSheet = true
+                        return
+                    }
+                    
                     // Next button in cards mode
                     if cardState.isLastCard {
                         // On last card, collect input and quit
@@ -290,7 +299,7 @@ struct NewButton: View {
                         _ = observedData.advanceToNextCard()
                     }
                 } else if isCardsPreviousButton && cardState.isCardsMode {
-                    // Previous button in cards mode - go back
+                    // Previous button in cards mode - go back (no validation needed)
                     _ = observedData.goToPreviousCard()
                 } else {
                     // Normal mode - original behavior

--- a/dialog/Views/ButtonBarView.swift
+++ b/dialog/Views/ButtonBarView.swift
@@ -290,6 +290,25 @@ struct NewButton: View {
                         return
                     }
                     
+                    // Execute onAdvance callback if configured
+                    if appArguments.onAdvance.present && !appArguments.onAdvance.value.isEmpty {
+                        let currentInput = observedData.collectCurrentUserInput()
+                        let cardId = cardState.currentCard?.configuration["cardId"].string
+                        let callbackResult = executeOnAdvanceCallback(
+                            command: appArguments.onAdvance.value,
+                            cardIndex: cardState.currentCardIndex,
+                            cardId: cardId,
+                            input: currentInput
+                        )
+                        
+                        if !callbackResult.success {
+                            // Callback failed - show error and don't advance
+                            observedData.sheetErrorMessage = callbackResult.errorMessage
+                            observedData.showSheet = true
+                            return
+                        }
+                    }
+                    
                     // Next button in cards mode
                     if cardState.isLastCard {
                         // On last card, collect input and quit

--- a/dialog/Views/ButtonBarView.swift
+++ b/dialog/Views/ButtonBarView.swift
@@ -55,6 +55,7 @@ struct ButtonBarView: View {
                         NewButton(label: observedData.args.buttonInfoTextOption.value == "nil" ? "" : observedData.args.buttonInfoTextOption.value,
                                     symbolName: observedData.args.buttonInfoSymbol.value,
                                     symbolIsVisible: observedData.args.buttonInfoSymbol.present,
+                                    keyboardShortcut: .init(.end),
                                     buttonFontSize: observedData.appProperties.buttonTextSize,
                                     buttonStyle: observedData.appProperties.buttonSize,
                                     action: observedData.args.buttonInfoActionOption.value,

--- a/dialog/Views/CheckboxView.swift
+++ b/dialog/Views/CheckboxView.swift
@@ -30,10 +30,13 @@ struct RenderToggles: View {
     }
 
     var body: some View {
-        VStack {
-            ForEach(0..<observedData.observedUserInputState.checkBoxes.count, id: \.self) {index in
-                HStack {
-                    if observedData.appProperties.checkboxControlStyle == "switch" {
+        // Guard against array size mismatch during card transitions
+        let checkboxCount = observedData.observedUserInputState.checkBoxes.count
+        if checkboxCount > 0 && checkboxCount == userInputState.checkBoxes.count {
+            VStack {
+                ForEach(0..<checkboxCount, id: \.self) {index in
+                    HStack {
+                        if observedData.appProperties.checkboxControlStyle == "switch" {
                         let _ = writeLog("Displaying switches instead of checkboxes")
                         if iconPresent {
                             if observedData.observedUserInputState.checkBoxes[index].icon != "" {
@@ -79,11 +82,12 @@ struct RenderToggles: View {
                     Divider().opacity(0.5)
                 }
             }
+            }
+            .font(.system(size: observedData.appProperties.labelFontSize))
+            .padding(10)
+            .background(Color.background.opacity(0.5))
+            .cornerRadius(8)
         }
-        .font(.system(size: observedData.appProperties.labelFontSize))
-        .padding(10)
-        .background(Color.background.opacity(0.5))
-        .cornerRadius(8)
     }
 }
 

--- a/dialog/Views/DropdownView.swift
+++ b/dialog/Views/DropdownView.swift
@@ -50,7 +50,9 @@ struct DropdownView: View {
     }
 
     var body: some View {
-        if observedData.args.dropdownValues.present && dropdownCount > 0 {
+        // Guard against array size mismatch during card transitions
+        // When cards change, userInputState may have different count than @State selectedOption
+        if observedData.args.dropdownValues.present && dropdownCount > 0 && selectedOption.count == userInputState.dropdownItems.count {
             VStack {
                 ForEach(0..<userInputState.dropdownItems.count, id: \.self) {index in
                     if userInputState.dropdownItems[index].style != "radio" {

--- a/dialog/Views/ListView.swift
+++ b/dialog/Views/ListView.swift
@@ -82,12 +82,16 @@ struct ListView: View {
 
 
     var body: some View {
-        if observedData.args.listItem.present {
+        // Guard against array access during card transitions
+        let listCount = userInputState.listItems.count
+        if observedData.args.listItem.present && listCount > 0 {
             let _ = writeLog("Displaying listitems")
             ScrollViewReader { proxy in
                 VStack {
-                    List(0..<userInputState.listItems.count, id: \.self, selection: $selection) {index in
+                    List(0..<listCount, id: \.self, selection: $selection) {index in
                         Button(action: {
+                            // Extra bounds check for safety during card transitions
+                            guard index < userInputState.listItems.count else { return }
                             if observedData.args.listSelectionEnabled.present {
                                 if selection.contains(index) {
                                     selection.remove(index)

--- a/dialog/Views/MessageContentView.swift
+++ b/dialog/Views/MessageContentView.swift
@@ -159,6 +159,7 @@ struct MessageContent: View {
                             .padding(.bottom, appDefaults.contentPadding)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.checkbox.rawValue):
                         CheckboxView(observedDialogContent: observedData)
+                            .id(observedData.currentCardIndex)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                             .frame(maxWidth: dataEntryMaxWidth)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.textfield.rawValue):
@@ -168,11 +169,13 @@ struct MessageContent: View {
                             .frame(maxWidth: dataEntryMaxWidth)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.dropdown.rawValue):
                         DropdownView(observedDialogContent: observedData)
+                            .id(observedData.currentCardIndex)
                             .padding(.bottom, appDefaults.contentPadding)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                             .frame(maxWidth: dataEntryMaxWidth, alignment: .leading)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.radiobutton.rawValue):
                         RadioView(observedDialogContent: observedData)
+                            .id(observedData.currentCardIndex)
                             .padding(.bottom, appDefaults.contentPadding)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                             .frame(maxWidth: dataEntryMaxWidth)

--- a/dialog/Views/MessageContentView.swift
+++ b/dialog/Views/MessageContentView.swift
@@ -155,6 +155,7 @@ struct MessageContent: View {
                             .padding(.bottom, appDefaults.contentPadding)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.listitem.rawValue):
                         ListView(observedDialogContent: observedData)
+                            .id(observedData.currentCardIndex)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                             .padding(.bottom, appDefaults.contentPadding)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.checkbox.rawValue):
@@ -164,6 +165,7 @@ struct MessageContent: View {
                             .frame(maxWidth: dataEntryMaxWidth)
                     case observedData.appProperties.viewOrder.firstIndex(of: ViewType.textfield.rawValue):
                         TextEntryView(observedDialogContent: observedData, textfieldContent: userInputState.textFields)
+                            .id(observedData.currentCardIndex)
                             .padding(.bottom, appDefaults.contentPadding)
                             .border(observedData.appProperties.debugBorderColour, width: 2)
                             .frame(maxWidth: dataEntryMaxWidth)

--- a/dialog/Views/PresentationView.swift
+++ b/dialog/Views/PresentationView.swift
@@ -61,8 +61,9 @@ struct PresentationView: View {
                                 .frame(maxWidth: content.size.width*sbWidthProportion)
                         } else {
                             ZStack {
-                                SolidColourView(colourValue: observedData.args.watermarkImage.present ? observedData.args.watermarkImage.value : "accent")
-
+                                SolidColourView(colourValue: observedData.args.watermarkImage.value.split(usingRegex: ",").first ?? "accent",
+                                                withGradient: observedData.args.watermarkImage.value.split(usingRegex: ",").last != "nogradient"
+                                                )
                                 VStack {
                                     if observedData.args.iconOption.present && observedData.args.iconOption.value != "default" {
                                         HStack {

--- a/dialog/Views/RadioView.swift
+++ b/dialog/Views/RadioView.swift
@@ -46,7 +46,9 @@ struct RadioView: View {
     }
 
     var body: some View {
-        if observedData.args.dropdownValues.present && radioCount > 0 {
+        // Guard against array size mismatch during card transitions
+        // When cards change, userInputState may have different count than @State selectedOption
+        if observedData.args.dropdownValues.present && radioCount > 0 && selectedOption.count == userInputState.dropdownItems.count {
             VStack {
                 ForEach(0..<userInputState.dropdownItems.count, id: \.self) {index in
                     if userInputState.dropdownItems[index].style == "radio" {

--- a/dialog/Views/SolidColourView.swift
+++ b/dialog/Views/SolidColourView.swift
@@ -33,6 +33,66 @@ struct SolidColourView: View {
     }
 }
 
-#Preview {
+struct GradientColourView: View {
+    var colours: [Color]
+    var angleDegrees: Double
+
+    /// Create a gradient view from an array of colour strings and a direction in degrees.
+    /// - Parameters:
+    ///   - colourValues: Comma-separated colour names or hex values (e.g. "red, green, blue, #FF8800").
+    ///                   Defaults to the equivalent of SolidColourView: a single colour with a
+    ///                   white-to-colour-to-black gradient overlay.
+    ///   - angleDegrees: The gradient direction in degrees (0 = bottom-to-top, 90 = left-to-right,
+    ///                   180 = top-to-bottom). Defaults to 180 (top-to-bottom).
+    init(colourValues: String = "accent", angleDegrees: Double = 90) {
+        let parsed = colourValues
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .map { $0.components(separatedBy: "=").last ?? "clear" }
+            .map { Color(argument: $0) }
+
+        // If only one colour was supplied, mimic SolidColourView's default gradient
+        if parsed.count < 2 {
+            let base = parsed.first ?? .clear
+            self.colours = [
+                .white.opacity(0.15),
+                base,
+                .black.opacity(0.15)
+            ]
+        } else {
+            self.colours = parsed
+        }
+        self.angleDegrees = angleDegrees
+    }
+
+    /// Convert an angle in degrees to a SwiftUI `UnitPoint` pair.
+    /// 0° = bottom-to-top, 90° = left-to-right, 180° = top-to-bottom, 270° = right-to-left.
+    private var gradientPoints: (start: UnitPoint, end: UnitPoint) {
+        let radians = angleDegrees * .pi / 180
+        // Unit circle: sin gives x component, cos gives y component.
+        // We negate cos so that 0° means "upward" (bottom-to-top) matching common CSS/design convention.
+        let dx = sin(radians)
+        let dy = -cos(radians)
+        let start = UnitPoint(x: 0.5 - dx / 2, y: 0.5 - dy / 2)
+        let end   = UnitPoint(x: 0.5 + dx / 2, y: 0.5 + dy / 2)
+        return (start, end)
+    }
+
+    var body: some View {
+        let points = gradientPoints
+        LinearGradient(
+            colors: colours,
+            startPoint: points.start,
+            endPoint: points.end
+        )
+        .ignoresSafeArea(.all)
+    }
+}
+
+#Preview("Solid Colour") {
     SolidColourView(colourValue: "blue")
 }
+#Preview("Gradient Colour") {
+    GradientColourView(colourValues: "red, green, blue, orange", angleDegrees: 135)
+}
+

--- a/dialog/Views/TextEntryView.swift
+++ b/dialog/Views/TextEntryView.swift
@@ -185,12 +185,54 @@ struct TextEntryView: View {
                                         }
                                         .onSubmit {
                                             userInputState.textFields[index].value = observedData.textFieldArray[index].value
-                                            // Call the same action as Button1
-                                            let button1action = observedData.args.button1ShellActionOption.present ?
-                                                observedData.args.button1ShellActionOption.value :
-                                                (observedData.args.button1ActionOption.present ? observedData.args.button1ActionOption.value : "")
-                                            let buttonShellAction = observedData.args.button1ShellActionOption.present
-                                            buttonAction(action: button1action, exitCode: 0, executeShell: buttonShellAction, observedObject: observedData)
+                                            
+                                            // Handle cards mode - advance to next card instead of exiting
+                                            if cardState.isCardsMode {
+                                                // Validate required fields first
+                                                let validation = validateRequiredFields(observedObject: observedData)
+                                                if !validation.isValid {
+                                                    observedData.sheetErrorMessage = validation.errorMessage
+                                                    observedData.showSheet = true
+                                                    return
+                                                }
+                                                
+                                                // Execute onAdvance callback if configured
+                                                if appArguments.onAdvance.present && !appArguments.onAdvance.value.isEmpty {
+                                                    let currentInput = observedData.collectCurrentUserInput()
+                                                    let cardId = cardState.currentCard?.configuration["cardId"].string
+                                                    let callbackResult = executeOnAdvanceCallback(
+                                                        command: appArguments.onAdvance.value,
+                                                        cardIndex: cardState.currentCardIndex,
+                                                        cardId: cardId,
+                                                        input: currentInput
+                                                    )
+                                                    
+                                                    if !callbackResult.success {
+                                                        observedData.sheetErrorMessage = callbackResult.errorMessage
+                                                        observedData.showSheet = true
+                                                        return
+                                                    }
+                                                }
+                                                
+                                                if cardState.isLastCard {
+                                                    // On last card, exit with collected input
+                                                    let button1action = observedData.args.button1ShellActionOption.present ?
+                                                        observedData.args.button1ShellActionOption.value :
+                                                        (observedData.args.button1ActionOption.present ? observedData.args.button1ActionOption.value : "")
+                                                    let buttonShellAction = observedData.args.button1ShellActionOption.present
+                                                    buttonAction(action: button1action, exitCode: 0, executeShell: buttonShellAction, shouldQuit: true, observedObject: observedData, isCardsMode: true)
+                                                } else {
+                                                    // Advance to next card
+                                                    _ = observedData.advanceToNextCard()
+                                                }
+                                            } else {
+                                                // Normal mode - original behavior
+                                                let button1action = observedData.args.button1ShellActionOption.present ?
+                                                    observedData.args.button1ShellActionOption.value :
+                                                    (observedData.args.button1ActionOption.present ? observedData.args.button1ActionOption.value : "")
+                                                let buttonShellAction = observedData.args.button1ShellActionOption.present
+                                                buttonAction(action: button1action, exitCode: 0, executeShell: buttonShellAction, observedObject: observedData)
+                                            }
                                         }
                                         .submitLabel(.done)
                                     

--- a/dialog/Views/TextEntryView.swift
+++ b/dialog/Views/TextEntryView.swift
@@ -81,9 +81,11 @@ struct TextEntryView: View {
     }
 
     var body: some View {
-        if observedData.args.textField.present {
+        // Guard against array size mismatch during card transitions
+        let textFieldCount = observedData.textFieldArray.count
+        if observedData.args.textField.present && textFieldCount == userInputState.textFields.count && textFieldCount == datepickerID.count - 1 {
             VStack {
-                ForEach(0..<observedData.textFieldArray.count, id: \.self) {index in
+                ForEach(0..<textFieldCount, id: \.self) {index in
                     if observedData.textFieldArray[index].editor {
                         VStack {
                             HStack {

--- a/dialog/Views/TitleView.swift
+++ b/dialog/Views/TitleView.swift
@@ -12,34 +12,58 @@ import Textual
 struct TitleView: View {
 
     @ObservedObject var observedData: DialogUpdatableContent
+    
+    var textAlignment: HorizontalAlignment = .center
+    var frameAlignment: Alignment = .center
+    var textOffset: CGFloat = 0
+    
+    init(observedData: DialogUpdatableContent) {
+        self.observedData = observedData
+        self.textOffset = observedData.appProperties.titleFontOffset
+        
+        switch observedData.appProperties.titleFontAlignment.lowercased() {
+        case "left":
+            self.textAlignment = .leading
+            self.frameAlignment = .leading
+        case "right":
+            self.textAlignment = .trailing
+            self.frameAlignment = .trailing
+            if observedData.appProperties.titleFontOffset > 0 {
+                // When using offsets and right alignment we want to ensure the offset is in the correct direction
+                self.textOffset = observedData.appProperties.titleFontOffset * -1
+            }
+        default:
+            self.textAlignment = .center
+            self.frameAlignment = .center
+        }
+    }
 
     var body: some View {
-        HStack {
-            if observedData.appProperties.titleFontAlignment.lowercased() == "right" {
-                Spacer()
+            VStack(alignment: textAlignment) {
+                InlineText(observedData.args.titleOption.value, parser: ColoredMarkdownParser())
+                    .font(
+                        observedData.appProperties.titleFontName.isEmpty ?
+                            .system(size: observedData.appProperties.titleFontSize, weight: observedData.appProperties.titleFontWeight) :
+                                .custom(observedData.appProperties.titleFontName, size: observedData.appProperties.titleFontSize)
+                    )
+                    .accessibilityHint(observedData.args.titleOption.value)
+                    
+                if observedData.args.subTitleOption.present {
+                    InlineText(observedData.args.subTitleOption.value, parser: ColoredMarkdownParser())
+                        .font(
+                            observedData.appProperties.titleFontName.isEmpty ?
+                                .system(size: observedData.appProperties.titleFontSize-10, weight: observedData.appProperties.titleFontWeight) :
+                                    .custom(observedData.appProperties.titleFontName, size: observedData.appProperties.titleFontSize-10)
+                        )
+                        .accessibilityHint(observedData.args.subTitleOption.value)
+                }
+                    
             }
-            InlineText(observedData.args.titleOption.value, parser: ColoredMarkdownParser())
-                .font(
-                    observedData.appProperties.titleFontName.isEmpty ?
-                    Font.system(size: observedData.appProperties.titleFontSize, weight: observedData.appProperties.titleFontWeight, design: .default) :
-                            .custom(observedData.appProperties.titleFontName, size: observedData.appProperties.titleFontSize)
-                )
-                .fontWeight(observedData.appProperties.titleFontWeight)
-                .foregroundColor(observedData.appProperties.titleFontColour)
-                .padding([.leading, .trailing], 20)
-            /*
-             Text(observedData.args.titleOption.value)
-             .titleFont(fontName: observedData.appProperties.titleFontName,
-             fontSize: observedData.appProperties.titleFontSize,
-             fontWeight: observedData.appProperties.titleFontWeight
-             )
-             .foregroundColor(observedData.appProperties.titleFontColour)
-             .accessibilityHint(observedData.args.titleOption.value)
-             */
-            if observedData.appProperties.titleFontAlignment.lowercased() == "left" {
-                Spacer()
-            }
-        }
+            .fontWeight(observedData.appProperties.titleFontWeight)
+            .foregroundColor(observedData.appProperties.titleFontColour)
+            .padding(appDefaults.topPadding)
+            .frame(maxWidth: .infinity, alignment: frameAlignment)
+            .offset(x: textOffset)
     }
 }
 

--- a/dialog/Views/WatermarkView.swift
+++ b/dialog/Views/WatermarkView.swift
@@ -50,7 +50,15 @@ struct WatermarkView: View {
         GeometryReader { window in
             ZStack {
                 if observedData.args.watermarkImage.value.range(of: "colo[u]?r=", options: .regularExpression) != nil {
-                    SolidColourView(colourValue: observedData.args.watermarkImage.value)
+                    SolidColourView(colourValue: observedData.args.watermarkImage.value.split(usingRegex: ",").first ?? "accent",
+                                    withGradient: observedData.args.watermarkImage.value.split(usingRegex: ",").last != "nogradient"
+                                    )
+                } else if observedData.args.watermarkImage.value.range(of: "gradient=", options: .regularExpression) != nil {
+                    if let colourValues = observedData.args.watermarkImage.value.split(usingRegex: "gradient=").last {
+                        // angle degrees is the last element if it contains the text angle=, otherwise it's 90
+                        GradientColourView(colourValues: colourValues.split(usingRegex: ":").first ?? "accent",
+                                           angleDegrees: Double(colourValues.split(usingRegex: ":").last?.split(usingRegex: "angle=").last ?? "90") ?? 90 )
+                    }
                 } else if observedData.args.watermarkFill.value == "fill" {
                     DisplayImage(observedData.args.watermarkImage.value, corners: false, rezize: true, content: .fill)
                         .scaledToFill()

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -7,42 +7,17 @@
 
 import SwiftUI
 import Combine
-import UserNotifications
 
 import SystemConfiguration
 
 var background = BlurWindowController()
 
-// AppDelegate and extension used for notifications
-class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+// AppDelegate for window and lifecycle management
+class AppDelegate: NSObject, NSApplicationDelegate {
 
     var monitor: PIDMonitor?
-    
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
-                didReceive response: UNNotificationResponse,
-                withCompletionHandler completionHandler:
-                                @escaping () -> Void) {
-
-        writeLog("reading notification", logLevel: .debug)
-
-        if response.notification.request.content.categoryIdentifier == "SD_NOTIFICATION" {
-            appvars.isProcessingNotification = true
-            processNotification(response: response)
-        } else {
-            writeLog("unknown notification type", logLevel: .debug)
-        }
-
-        // call the completion handler when done.
-        completionHandler()
-        // quit dialog since we dont need to show anything
-        if appvars.isProcessingNotification {
-            //quitDialog(exitCode: appDefaults.exitNow.code)
-        }
-    }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
-        UNUserNotificationCenter.current().delegate = self
-
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -159,9 +134,7 @@ struct dialogApp: App {
 
         appvars.debugMode = CLOptionPresent(optionName: appArguments.debug)
 
-        if CommandLine.arguments.count > 1 {
-            appvars.isProcessingNotification = false
-        } else {
+        if CommandLine.arguments.count <= 1 {
             appvars.noargs = true
         }
 
@@ -180,21 +153,7 @@ struct dialogApp: App {
         // get all the command line option values
         processCLOptionValues()
 
-        if !(appArguments.setAppIcon.present ||
-            appArguments.getVersion.present ||
-            appArguments.buyCoffee.present ||
-            appArguments.helpOption.present ||
-            appArguments.licence.present) {
-            checkNotificationAuthorisation(notificationPresent: appArguments.notification.present)
-        }
-
         captureQuitKey(keyValue: appArguments.quitKey.value)
-
-        // check if we are sending a notification
-        if checkForDialogNotificationMode(appArguments) {
-            writeLog("Notification sent")
-            quitDialog(exitCode: 0)
-        }
 
         // check for jamfhelper mode
         if appArguments.jamfHelperMode.present {
@@ -259,7 +218,7 @@ struct dialogApp: App {
     var body: some Scene {
         
         WindowGroup {
-            if !appArguments.notification.present && !appvars.noargs {
+            if !appvars.noargs {
                 let _ = appvars.debugMode ? print("DEBUG: Checking modes - mini:\(appArguments.miniMode.present) inspect:\(appArguments.inspectMode.present) presentation:\(appArguments.presentationMode.present)") : ()
                 ZStack {
                     if appArguments.miniMode.present {

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -7,17 +7,39 @@
 
 import SwiftUI
 import Combine
+import UserNotifications
 
 import SystemConfiguration
 
 var background = BlurWindowController()
 
 // AppDelegate for window and lifecycle management
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
 
     var monitor: PIDMonitor?
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate (legacy path)
+    // Notifications sent via the main app bundle (without --style) are handled here.
+    // This path is deprecated and will be removed in a future major version.
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        writeLog("reading notification response", logLevel: .debug)
+        if response.notification.request.content.categoryIdentifier == "SD_NOTIFICATION" {
+            appvars.isProcessingNotification = true
+            processNotification(response: response)
+        } else {
+            writeLog("unknown notification type", logLevel: .debug)
+        }
+        completionHandler()
+        if appvars.isProcessingNotification {
+            quitDialog(exitCode: 0)
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -153,7 +175,24 @@ struct dialogApp: App {
         // get all the command line option values
         processCLOptionValues()
 
+        // Legacy notification path: --notification without --style routes through the main app bundle.
+        // This preserves compatibility with existing MDM notification-settings profiles.
+        // Deprecated: use --style banner or --style alert with dialogcli for new deployments.
+        if !(appArguments.setAppIcon.present ||
+             appArguments.getVersion.present ||
+             appArguments.buyCoffee.present ||
+             appArguments.helpOption.present ||
+             appArguments.licence.present) {
+            checkNotificationAuthorisation(notificationPresent: appArguments.notification.present)
+        }
+
         captureQuitKey(keyValue: appArguments.quitKey.value)
+
+        // Check if we are sending a notification via the legacy path (no --style argument).
+        if checkForDialogNotificationMode(appArguments) {
+            writeLog("Notification sent via legacy path (main app bundle)")
+            quitDialog(exitCode: 0)
+        }
 
         // check for jamfhelper mode
         if appArguments.jamfHelperMode.present {
@@ -218,7 +257,7 @@ struct dialogApp: App {
     var body: some Scene {
         
         WindowGroup {
-            if !appvars.noargs {
+            if !appArguments.notification.present && !appvars.noargs {
                 let _ = appvars.debugMode ? print("DEBUG: Checking modes - mini:\(appArguments.miniMode.present) inspect:\(appArguments.inspectMode.present) presentation:\(appArguments.presentationMode.present)") : ()
                 ZStack {
                     if appArguments.miniMode.present {

--- a/dialogcli/dialogcli.swift
+++ b/dialogcli/dialogcli.swift
@@ -60,11 +60,14 @@ struct DialogLauncher: ParsableCommand {
         //fputs("my pid \(myPid)\n", stderr)
 
         // --- Notification routing ---
-        // When --notification is present, delegate to the appropriate helper bundle
-        // embedded inside Dialog.app/Contents/Helpers/. The --style argument selects
-        // banner (default) or alert delivery style.
-        if argPresent("--notification", in: passthroughArgs) {
-            let style = argValue("--style", in: passthroughArgs)?.lowercased() ?? "banner"
+        // When --notification AND --style are both present, delegate to the appropriate
+        // helper bundle embedded inside Dialog.app/Contents/Helpers/.
+        // If --style is absent, fall through to the main Dialog binary which handles
+        // notifications via the main app bundle ID (legacy path, preserved for backwards
+        // compatibility with existing MDM notification-settings profiles).
+        let notificationStyle = argValue("--style", in: passthroughArgs)?.lowercased()
+        if argPresent("--notification", in: passthroughArgs) && notificationStyle != nil {
+            let style = notificationStyle!
             let helperName: String
             switch style {
             case "alert":
@@ -285,13 +288,12 @@ struct DialogLauncher: ParsableCommand {
         var stdout: String = ""
         var stderrOutput: String = ""
 
-        // Set up a handler to stream stderr in real-time
+        // Collect stderr output for the return value; callers are responsible for forwarding it.
         let stderrHandle = stderrPipe.fileHandleForReading
         stderrHandle.readabilityHandler = { handle in
             let data = handle.availableData
             if let line = String(data: data, encoding: .utf8), !line.isEmpty {
                 stderrOutput += line
-                fputs(line, stderr)
             }
         }
 

--- a/dialogcli/dialogcli.swift
+++ b/dialogcli/dialogcli.swift
@@ -68,9 +68,9 @@ struct DialogLauncher: ParsableCommand {
             let helperName: String
             switch style {
             case "alert":
-                helperName = "DialogNotifier-Alert"
+                helperName = "Dialog Alert"
             default:
-                helperName = "DialogNotifier-Banner"
+                helperName = "Dialog Banner"
             }
 
             // Remove --style and its value from args before forwarding — the helper

--- a/dialogcli/dialogcli.swift
+++ b/dialogcli/dialogcli.swift
@@ -16,6 +16,18 @@ struct CommandResult {
     let stderr: String
 }
 
+/// Returns the value of `--arg` from an argument list, or nil if absent / no value follows.
+private func argValue(_ arg: String, in args: [String]) -> String? {
+    guard let idx = args.firstIndex(of: arg), idx + 1 < args.count else { return nil }
+    let value = args[idx + 1]
+    return value.hasPrefix("-") ? nil : value
+}
+
+/// Returns true if `--flag` is present in an argument list.
+private func argPresent(_ flag: String, in args: [String]) -> Bool {
+    args.contains(flag)
+}
+
 @main
 struct DialogLauncher: ParsableCommand {
     static let process = Process()
@@ -46,7 +58,55 @@ struct DialogLauncher: ParsableCommand {
         // get my process id
         let myPid = getpid()
         //fputs("my pid \(myPid)\n", stderr)
-        
+
+        // --- Notification routing ---
+        // When --notification is present, delegate to the appropriate helper bundle
+        // embedded inside Dialog.app/Contents/Helpers/. The --style argument selects
+        // banner (default) or alert delivery style.
+        if argPresent("--notification", in: passthroughArgs) {
+            let style = argValue("--style", in: passthroughArgs)?.lowercased() ?? "banner"
+            let helperName: String
+            switch style {
+            case "alert":
+                helperName = "DialogNotifier-Alert"
+            default:
+                helperName = "DialogNotifier-Banner"
+            }
+
+            // Remove --style and its value from args before forwarding — the helper
+            // doesn't recognise the window-style argument.
+            var notifierArgs = passthroughArgs
+            if let styleIdx = notifierArgs.firstIndex(of: "--style") {
+                notifierArgs.remove(at: styleIdx)
+                if styleIdx < notifierArgs.count, !notifierArgs[styleIdx].hasPrefix("-") {
+                    notifierArgs.remove(at: styleIdx)
+                }
+            }
+
+            // Locate the helper relative to our own app bundle
+            var helperBinary: String? = nil
+            if let appBundle = findAppBundlePath() {
+                let candidate = "\(appBundle.path)/Contents/Helpers/\(helperName).app/Contents/MacOS/\(helperName)"
+                if FileManager.default.fileExists(atPath: candidate) {
+                    helperBinary = candidate
+                } else {
+                    fputs("ERROR: Helper not found at expected path: \(candidate)\n", stderr)
+                }
+            } else {
+                fputs("ERROR: Could not locate app bundle from executable path: \(resolvedExecutablePath())\n", stderr)
+            }
+
+            guard let binary = helperBinary else {
+                fputs("ERROR: Cannot find \(helperName) helper inside app bundle\n", stderr)
+                throw ExitCode(255)
+            }
+
+            let result = runCommand(binary: binary, args: notifierArgs)
+            fputs(result.stderr, stderr)
+            throw ExitCode(result.status)
+        }
+        // --- End notification routing ---
+
         // Define default paths and binary locations
         let defaultCommandFile = "/var/tmp/dialog.log"
         let dialogAppPath = "/Library/Application Support/Dialog/Dialog.app"


### PR DESCRIPTION
Consolidates several feature branches for future 3.1.0 release


### Cards Workflow (Multi-Step Dialogs)

- Define an array of `cards` in your JSON, each with its own title, message, icon, and input fields
- Users can navigate **forward and backward** between cards, with input preserved across navigation
- Accumulated input from all cards is returned as a single JSON output on completion
- Global configuration properties (defined outside the `cards` array) act as defaults, overridable per card
- New `--onadvance` argument allows a shell script to run when the user advances between cards — the script receives the current card index, card ID, and user input via stdin as JSON, and can block advancement by exiting with a non-zero code
- Required field validation is enforced per card before advancing
- Button bar adapts automatically (Back / Next / Finish) based on card position

### Separate Notification Apps

Notifications are now delivered by dedicated helper apps (`Dialog Alert.app` and `Dialog Banner.app`) rather than Dialog.app itself.

- Separate apps for **Alert** and **Banner** style notifications, ensuring the correct macOS notification presentation style
- Helper apps are bundled inside `Dialog.app/Contents/Helpers/` and are automatically invoked by the `dialog` CLI launcher when `--style alert` or `--style banner` is used alongside `--notification`
- The "Approve Notifications" alert now persists until dismissed — it no longer auto-dismisses
- New app icons for the notifier helper apps

Sending notifications via `Dialog.app` directly is deprecated. A warning is now printed to `stderr` when this legacy usage is detected. This behaviour will be removed in a future release. 

### Banner Enhancements

The `--bannerimage` argument now supports solid colour and gradient options in addition to image files.

Colours are comma-separated names or hex values. The optional `:angle=<degrees>` suffix sets the gradient direction (0 = bottom-to-top, 90 = left-to-right, 180 = top-to-bottom; default is 90).

The same `colour=` and `gradient=` keywords also work for `--background` (watermark) images.


### Title Enhancements

**Subtitle Argument (for use with `--title` and `--bannertitle`)**

`--subtitle` allows you to add a subtitle below the main title. This is useful for providing additional context or instructions to the user.

The subtitle text is styled with the same font properties as the title but at 75% opacity. When a banner image is used with `--bannertext enable`, the subtitle also adopts the banner text styling (white colour, shadow).

**Title Font Offset**

`--titlefont` now accepts an `offset=<float>` parameter to nudge the title text vertically within its container. Useful when using banner images with overlaid title text but can also be used in regular dialogs to fine-tune title positioning.


### Previously Undocumented Arguments

The following arguments existed in earlier releases but were not documented. Help text is now available via `--help <argument>` for each:

| Argument | Description |
|---|---|
| `--helpalignment [left\|centre\|right]` | Sets the text alignment of the help sheet message |
| `--helpsheetbuttontext <text>` | Sets the dismiss button label on the help sheet (default: `OK`) |
| `--iconalttext <text>` | Accessibility label for the dialog icon |
| `--bannerheight <num>` | Sets the height of the banner image area in points |
| `--selectstyle [list\|radio\|searchable\|multiselect]` | Global display style for all select lists |
| `--progresstextalignment [left\|right]` | Horizontal alignment of progress bar text (default: centred) |
| `--verbose` | Enable verbose log output to stderr |
| `--eula` | Display message in EULA mode (monospaced, scrollable) |
| `--alwaysreturninput` | Return user input for all exit codes, not just exit code 0 |
| `--hidetimer` | Hide the countdown indicator during image carousel autoplay transitions |
| `--listfonts` | Print all available font names to stdout |

---

### Bug Fixes

- **Fix #632** — Multiselect dropdown correctly renders selected tags in a scrollable flow layout
