### PR TITLE
fix: correct spelling occured->occurred in error messages

### DIFF
--- a/dialog/Functions/Images.swift
+++ b/dialog/Functions/Images.swift
@@ -51,10 +51,10 @@ func getImageFromPath(fileImagePath: String, imgWidth: CGFloat? = .infinity, img
         imageData = try NSData(contentsOf: urlPath as URL)
     } catch {
         if returnErrorImage! {
-            writeLog("An error occured - returning error image")
+            writeLog("An error occurred - returning error image")
             return errorImage
         } else {
-            writeLog("An error occured - exiting")
+            writeLog("An error occurred - exiting")
             quitDialog(exitCode: appDefaults.exit201.code, exitMessage: "\(appDefaults.exit201.message) \(fileImagePath)", observedObject: DialogUpdatableContent())
         }
     }


### PR DESCRIPTION
Fixes typo in error messages in dialog/Functions/Images.swift

2 corrections:
- Line 54: `An error occured` → `An error occurred`
- Line 57: `An error occured` → `An error occurred`

Both are user-facing error messages shown via writeLog().