### PR TITLE
Fix primary button actions

### DIFF
--- a/dialog/Views/ButtonBarView.swift
+++ b/dialog/Views/ButtonBarView.swift
@@ -106,6 +106,10 @@ struct ButtonBarView: View {
                           keyboardShortcut: .defaultAction,
                           buttonFontSize: observedData.appProperties.buttonTextSize,
                           buttonStyle: observedData.appProperties.buttonSize,
+                          action: observedData.args.button1ShellActionOption.present
+                              ? observedData.args.button1ShellActionOption.value
+                              : observedData.args.button1ActionOption.value,
+                          isShellCommand: observedData.args.button1ShellActionOption.present,
                           shouldQuit: true,
                           exitCode: 0,
                           observedData: observedData


### PR DESCRIPTION
Button 1 actions were not being passed into the primary button, so `--button1action` and `--button1shellaction` had no effect when the button was clicked.

This wires the primary `NewButton` to use the shell action when present, otherwise the regular button action, and marks shell actions so they execute through the existing shell path.

Fixes #685